### PR TITLE
Allow multiple Logical Files; change usage of file_set_number; re-adequate the tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ from dliswriter import DLISFile, enums
 
 df = DLISFile()
 
-df.add_origin("MY-ORIGIN")  # required; can contain metadata about the well, scan procedure, etc.
+lf = df.add_logical_file()  # a DLIS file is basically comprised of independent fully self-contained logical files
+
+lf.add_origin("MY-ORIGIN")  # required; can contain metadata about the well, scan procedure, etc.
 
 # define channels with numerical data and additional information
 n_rows = 100  # all datasets must have the same number of rows
-ch1 = df.add_channel('DEPTH', data=np.linspace(0, 10, n_rows), units=enums.Unit.METER)
-ch2 = df.add_channel("RPM", data=np.arange(n_rows) % 10)
-ch3 = df.add_channel("AMPLITUDE", data=np.random.rand(n_rows, 5))
+ch1 = lf.add_channel('DEPTH', data=np.linspace(0, 10, n_rows), units=enums.Unit.METER)
+ch2 = lf.add_channel("RPM", data=np.arange(n_rows) % 10)
+ch3 = lf.add_channel("AMPLITUDE", data=np.random.rand(n_rows, 5))
 
 # define frame, referencing the above defined channels
-main_frame = df.add_frame("MAIN-FRAME", channels=(ch1, ch2, ch3), index_type=enums.FrameIndexType.BOREHOLE_DEPTH)
+main_frame = lf.add_frame("MAIN-FRAME", channels=(ch1, ch2, ch3), index_type=enums.FrameIndexType.BOREHOLE_DEPTH)
 
 # write the data and metadata to a physical DLIS file
 df.write('./new_dlis_file.DLIS')

--- a/docs/developerguide/lrtypes/eflrs/implemented.rst
+++ b/docs/developerguide/lrtypes/eflrs/implemented.rst
@@ -10,7 +10,7 @@ Note: the standard defines several more types of EFLRs.
 
 File Header
 ^^^^^^^^^^^
-File Header must immediately follow a :ref:`Storage Unit Label <SUL>` of the file.
+Every Logical File must have a (single) File Header.
 Its length must be exactly 124 bytes.
 The ``identifier`` attribute of the File Header represents the name of the DLIS file.
 It should be a string of max 65 characters.
@@ -20,14 +20,17 @@ It should be a string of max 65 characters.
 
 Origin
 ^^^^^^
-Every DLIS file must contain at least one Origin. Usually, it immediately follows the `File Header`_.
+Every Logical File file must contain at least one Origin. Usually, it immediately follows the `File Header`_.
 The Origin keeps key information related to the scanned well, the scan procedure, producer, etc.
 The ``creation_time`` :ref:`Attribute <Attribute>` of Origin, if not explicitly specified, is set to the current
 date and time (when the object is initialised).
 
-The ``file_set_number`` :ref:`Attribute <Attribute>` of an Origin (assigned by user or randomly generated) is used as an Origin reference
-in other DLIS objects. By default, the ``file_set_number`` of the first defined Origin is assigned to all other objects.
-To indicate that an object originally comes from a different file, the user should create an additional Origin
+The ``origin_reference`` :ref:`Attribute <Attribute>` of an Origin (assigned by user or automatically generated) is used
+as an Origin reference in other DLIS objects. By default, the ``origin_reference`` of the first defined Origin is assigned to
+all other objects of its Logical File.
+
+To indicate that an object originally comes from a different logical file, the user should create another Logical File,
+an Origin for it its defining origin additional Origin
 with the relevant information and pass its ``file_set_number`` when creating the objects belonging to that Origin.
 
 From RP66:

--- a/docs/developerguide/writingfile/dlisfileobject.rst
+++ b/docs/developerguide/writingfile/dlisfileobject.rst
@@ -27,8 +27,9 @@ from the top level - a ``DLISFile``:
 .. code-block:: python
 
     dlis_file = DLISFile()
-    a_channel = dlis_file.add_channel(...)
-    an_axis = dlis_file.add_axis(...)
+    logical_file = dlis_file.add_logical_file()  # a DLIS file is basically comprised of independent fully self-contained logical files
+    a_channel = logical_file.add_channel(...)
+    an_axis = logical_file.add_axis(...)
 
 
 In order to mark relations between objects, a 'lower-level' object should be created first and then
@@ -36,8 +37,8 @@ passed as argument when creating a 'higher-level' object:
 
 .. code-block:: python
 
-    a_frame = dlis_file.add_frame(..., channels=(a_channel, ...))   # frame can have multiple channels
-    a_computation = dlis_file.add_computation(..., axis=an_axis)    # computation can only have 1 axis
+    a_frame = logical_file.add_frame(..., channels=(a_channel, ...))   # frame can have multiple channels
+    a_computation = logical_file.add_computation(..., axis=an_axis)    # computation can only have 1 axis
 
 
 This makes it trivial to reuse already defined 'lower-level' objects as many times as needed:
@@ -45,8 +46,8 @@ This makes it trivial to reuse already defined 'lower-level' objects as many tim
 .. code-block:: python
 
     # (multiple axes possible for both Parameter and Channel)
-    a_param = dlis_file.add_parameter(..., axis=(an_axis, ...))
-    another_channel = dlis_file.add_channel(..., axis=(an_axis, ...))
+    a_param = logical_file.add_parameter(..., axis=(an_axis, ...))
+    another_channel = logical_file.add_channel(..., axis=(an_axis, ...))
 
 
 As shown in the :doc:`user guide <../../userguide/minimalexample>`, once all required objects are defined,

--- a/docs/developerguide/writingfile/dliswriterobject.rst
+++ b/docs/developerguide/writingfile/dliswriterobject.rst
@@ -4,8 +4,6 @@ DLISWriter and auxiliary objects
 Given the iterable of logical records, provided by the ``DLISFile``,
 a ``DLISWriter`` iterates over the logical records and for each one:
 
-#. Assigns an ``origin_reference`` to all objects in the file.
-   The origin reference is the ``file_set_number`` of the :ref:`Origin` object defined in the file.
 #. Calls for creation of bytes describing that logical record
    (see :ref:`Converting to bytes`)
 #. If the bytes sequence is too long to fit into a single visible record,

--- a/docs/userguide/compatibilityissues.rst
+++ b/docs/userguide/compatibilityissues.rst
@@ -33,8 +33,9 @@ the following code:
 
     with high_compatibility_mode:
         df = DLISFile()
-        df.add_origin("MY-ORIGIN")
-        ch1 = df.add_channel('Depth', data=np.arange(100) / 10, units=Renums.Unit.METER)
+        lf = df.add_logical_file()
+        lf.add_origin("MY-ORIGIN")
+        ch1 = lf.add_channel('Depth', data=np.arange(100) / 10, units=Renums.Unit.METER)
 
 
 will raise a ``ValueError``:

--- a/docs/userguide/extendingmetadata.rst
+++ b/docs/userguide/extendingmetadata.rst
@@ -1,7 +1,7 @@
 Extending basic metadata
 ========================
 As mentioned above, initialising :ref:`DLISFile` automatically constructs :ref:`Storage Unit Label <SUL>`
-and :ref:`File Header`.
+and each initialised LogicalFile constructs :ref:`File Header`.
 However, the definition of each of these can be further tuned.
 The same applies to :ref:`Origin`, which is the container for key meta-data concerning the well, company, operation set-up etc.
 
@@ -14,15 +14,18 @@ The same applies to :ref:`Origin`, which is the container for key meta-data conc
       set_identifier="MY-SET",
       sul_sequence_number=5,
       max_record_length=4096,
-      fh_id="MY-FILE-HEADER",
-      fh_sequence_number=8
+    )
+
+    first_logical_file = df.add_logical_file(
+      fh_id=in_fheaderid_truncated,
+      fh_sequence_number=int(in_fheader.sequencenr),
+      fh_identifier=str(int(in_fheader.name)),
     )
 
     # add Origin with more details
     # see more available keyword arguments in DLISFile.add_origin()
-    origin = df.add_origin(
+    origin = first_logical_file.add_origin(
       'MY-ORIGIN',
-      file_id='MY-FILE-ID',
       file_set_name='MY-FILE-SET-NAME',
       file_set_number=11,
       file_number=22,

--- a/examples/create_dlis_equivalent_frames.py
+++ b/examples/create_dlis_equivalent_frames.py
@@ -20,15 +20,16 @@ install_colored_logger(logging.getLogger('dliswriter'))
 
 
 # create DLISFile instance; optionally, pass arguments for creating file header & storage unit label
-df = DLISFile(
-    sul_sequence_number=2,
+df = DLISFile(sul_sequence_number=2)
+
+lf = df.add_logical_file(
     fh_sequence_number=2,
     fh_id="MAIN FILE",
     fh_identifier="X"
 )
 
 # add origin - required item
-df.add_origin(
+lf.add_origin(
     "DEFAULT ORIGIN",
     file_set_number=80,
     company="XXX"
@@ -37,20 +38,20 @@ df.add_origin(
 
 # define frame 1
 n_rows_1 = 100
-ch_depth_1 = df.add_channel(
+ch_depth_1 = lf.add_channel(
     'DEPTH',
     data=np.arange(n_rows_1),
     units=enums.Unit.METER
 )
-ch_rpm_1 = df.add_channel(
+ch_rpm_1 = lf.add_channel(
     "RPM",
     data=10 * np.random.rand(n_rows_1)
 )
-ch_amp_1 = df.add_channel(
+ch_amp_1 = lf.add_channel(
     "AMPLITUDE",
     data=np.random.rand(n_rows_1, 10)
 )
-frame1 = df.add_frame(
+frame1 = lf.add_frame(
     "FRAME1",
     channels=(ch_depth_1, ch_rpm_1, ch_amp_1),
     index_type=enums.FrameIndexType.BOREHOLE_DEPTH
@@ -59,20 +60,20 @@ frame1 = df.add_frame(
 
 # define frame 2
 n_rows_2 = 200
-ch_depth_2 = df.add_channel(
+ch_depth_2 = lf.add_channel(
     'DEPTH',
     data=np.arange(n_rows_2),
     units=enums.Unit.METER
 )
-ch_rpm_2 = df.add_channel(
+ch_rpm_2 = lf.add_channel(
     "RPM",
     data=(np.arange(n_rows_2) % 10).astype(np.int32)
 )
-ch_amp_2 = df.add_channel(
+ch_amp_2 = lf.add_channel(
     "AMPLITUDE",
     data=np.arange(n_rows_2 * 5).reshape(n_rows_2, 5) % 6
 )
-frame2 = df.add_frame(
+frame2 = lf.add_frame(
     "FRAME2",
     channels=(ch_depth_2, ch_rpm_2, ch_amp_2),
     index_type=enums.FrameIndexType.BOREHOLE_DEPTH

--- a/examples/create_synth_dlis.py
+++ b/examples/create_synth_dlis.py
@@ -10,107 +10,81 @@ from utils import install_colored_logger
 
 
 # colored logs output
-install_colored_logger(logging.getLogger('dliswriter'))
+install_colored_logger(logging.getLogger("dliswriter"))
 
 
 # create DLISFile instance; optionally, pass custom parameters for file header and storage unit label
-df = DLISFile(
-    fh_id="DEFAULT FILE HEADER",
-    fh_identifier="3"
-)
+df = DLISFile(fh_id="DEFAULT FILE HEADER", fh_identifier="3")
 
 # add origin
-origin = df.add_origin(
-    "DEFAULT ORIGIN",
-    company="XXX",
-    order_number="352"
+origin = df.add_origin("DEFAULT ORIGIN", company="XXX", order_number="352")
+origin.creation_time.value = datetime(
+    year=2023, month=12, day=6, hour=12, minute=30, second=5
 )
-origin.creation_time.value = datetime(year=2023, month=12, day=6, hour=12, minute=30, second=5)
 
 # multiple origins can be added;
-# the file_set_number of the first origin will be used as origin_reference in all objects automatically
-# but you can also choose to pass other origins' file_set_number as the reference
+# the origin_reference of the first origin will be used as origin_reference in all objects automatically
+# but you can also choose to pass other origins' origin_reference as the reference
 # to indicate that a given object belongs to one of the other origins
-origin2 = df.add_origin(
-    "ADDITIONAL ORIGIN",
-    well_name="XYZ",
-    company="ABC"
-)
+origin2 = df.add_origin("ADDITIONAL ORIGIN", well_name="XYZ", company="ABC")
 origin3 = df.add_origin(
-    "ANOTHER ORIGIN",
-    well_name="XYZ",
-    company="another company",
-    file_set_number=35  # file set number is used as origin reference; can be passed explicitly
+    "ANOTHER ORIGIN", well_name="XYZ", company="another company", origin_reference=35
 )
 
 
 # define axes - metadata objects for channels
 ax1 = df.add_axis(
-    'AXIS1',
-    coordinates=["40 23' 42.8676'' N", "27 47' 32.8956'' E"],
-    axis_id='AXIS 1'
+    "AXIS1", coordinates=["40 23' 42.8676'' N", "27 47' 32.8956'' E"], axis_id="AXIS 1"
 )
 ax1.spacing.value = 0.2
 ax1.spacing.units = enums.Unit.METER
 
 ax2 = df.add_axis(
-    'AXIS2',
+    "AXIS2",
     spacing=5,
     coordinates=[1, 2, 3.5],
-    origin_reference=origin2.file_set_number.value  # mark ax2 as belonging to origin2
+    origin_reference=origin2.origin_reference,  # mark ax2 as belonging to origin2
 )
 
-ax3 = df.add_axis(
-    "AXIS3",
-    spacing=0.1,
-    coordinates=[0]
-)
+ax3 = df.add_axis("AXIS3", spacing=0.1, coordinates=[0])
 
 
 # define long_names - descriptions for channels, parameters, and computations
-long_name1 = df.add_long_name(
-    "LONG-NAME1",
-    quantity="23",
-    standard_symbol="ABC"
-)
+long_name1 = df.add_long_name("LONG-NAME1", quantity="23", standard_symbol="ABC")
 long_name2 = df.add_long_name(
-    "LONG-NAME-2",
-    entity_part="X",
-    source_part_number=["121.111"]
+    "LONG-NAME-2", entity_part="X", source_part_number=["121.111"]
 )
 long_name3 = df.add_long_name(
-    "ANOTHER LONG NAME",
-    conditions=["At Standard Temperature"]
+    "ANOTHER LONG NAME", conditions=["At Standard Temperature"]
 )
 
 
 # define frame 1: depth-based with 4 channels, 100 rows each
 n_rows_depth = 100
 ch1 = df.add_channel(
-    'DEPTH',
-    data=np.arange(n_rows_depth) / 10 - 3,  # index channel - always scalar, i.e. 1D data
-    units=enums.Unit.METER
+    "DEPTH",
+    data=np.arange(n_rows_depth) / 10
+    - 3,  # index channel - always scalar, i.e. 1D data
+    units=enums.Unit.METER,
 )
 ch2 = df.add_channel(
-    "RPM",
-    data=(np.arange(n_rows_depth) % 10).astype(np.int32) - 2,  # 1D data
-    axis=ax3
+    "RPM", data=(np.arange(n_rows_depth) % 10).astype(np.int32) - 2, axis=ax3  # 1D data
 )
 ch3 = df.add_channel(
     "AMPLITUDE",
     data=np.random.rand(n_rows_depth, 5),  # 2D data - 5 columns
     cast_dtype=np.float32,
-    long_name=long_name3
+    long_name=long_name3,
 )
 ch4 = df.add_channel(
-    'COMPUTED_CHANNEL',
+    "COMPUTED_CHANNEL",
     data=np.random.randint(0, 100, dtype=np.uint8, size=n_rows_depth),
-    long_name=long_name1
+    long_name=long_name1,
 )
 main_frame = df.add_frame(
     "MAIN FRAME",
     channels=(ch1, ch2, ch3, ch4),
-    index_type=enums.FrameIndexType.BOREHOLE_DEPTH
+    index_type=enums.FrameIndexType.BOREHOLE_DEPTH,
 )
 
 
@@ -118,77 +92,71 @@ main_frame = df.add_frame(
 n_rows_time = 200
 ch5 = df.add_channel(
     # index channel for frame 2
-    'TIME',
+    "TIME",
     data=np.arange(n_rows_time),
     cast_dtype=np.uint32,
     units=enums.Unit.SECOND,
-    axis=ax3
+    axis=ax3,
 )
 ch6 = df.add_channel(
-    'TEMPERATURE',
+    "TEMPERATURE",
     data=np.random.randint(-10, 30, size=n_rows_time, dtype=np.int8),
     cast_dtype=np.int16,
-    units=enums.Unit.DEGREE_CELSIUS
+    units=enums.Unit.DEGREE_CELSIUS,
 )
 second_frame = df.add_frame(
-    'TIME FRAME',
-    channels=(ch5, ch6),
-    index_type=enums.FrameIndexType.NON_STANDARD
+    "TIME FRAME", channels=(ch5, ch6), index_type=enums.FrameIndexType.NON_STANDARD
 )
 
 
 # zones
 zone1 = df.add_zone(
-    'DEPTH-ZONE',
-    domain=enums.ZoneDomain.BOREHOLE_DEPTH,
-    minimum=2,
-    maximum=4.5
+    "DEPTH-ZONE", domain=enums.ZoneDomain.BOREHOLE_DEPTH, minimum=2, maximum=4.5
 )
 dt = datetime.now()
 zone2 = df.add_zone(
-    'TIME-ZONE',
+    "TIME-ZONE",
     domain=enums.ZoneDomain.TIME,
     minimum=dt - timedelta(hours=3),
     maximum=dt - timedelta(minutes=30),
-    origin_reference=origin3.file_set_number.value  # associated with origin 3
+    origin_reference=origin3.origin_reference,  # associated with origin 3
 )
 zone3 = df.add_zone(
-    'VDEPTH-ZONE',
+    "VDEPTH-ZONE",
     domain=enums.ZoneDomain.VERTICAL_DEPTH,
     minimum=10,
     maximum=20,
-    origin_reference=origin2.file_set_number.value  # associated with origin 2
+    origin_reference=origin2.origin_reference,  # associated with origin 2
 )
 
 
 # splices - using zones & channels
 splice1 = df.add_splice(
-    'SPLICE1',
-    input_channels=(ch1,),
-    output_channel=ch4,
-    zones=(zone1,)
+    "SPLICE1", input_channels=(ch1,), output_channel=ch4, zones=(zone1,)
 )
 splice2 = df.add_splice(
-    'SPLICE2',
-    input_channels=(ch5, ch2),
-    output_channel=ch6,
-    zones=(zone2, zone3)
+    "SPLICE2", input_channels=(ch5, ch2), output_channel=ch6, zones=(zone2, zone3)
 )
 
 
 # parameters - using zones, axes, and long name
 parameter1 = df.add_parameter(
-    'PARAM1',
+    "PARAM1",
     long_name="Parameter nr 1",  # long_name can be str or a LongName object
     axis=ax1,
-    values={'value': [1], 'units': enums.Unit.INCH}  # specifying value and units of the value in one line
+    values={
+        "value": [1],
+        "units": enums.Unit.INCH,
+    },  # specifying value and units of the value in one line
 )
 parameter2 = df.add_parameter(
-    'PARAM2',
+    "PARAM2",
     zones=(zone2,),
     long_name=long_name2,
-    values=[["val1", "val2", "val3"]],  # specifying only values; units can be added by: parameter2.values.units = ...
-    dimension=[3]
+    values=[
+        ["val1", "val2", "val3"]
+    ],  # specifying only values; units can be added by: parameter2.values.units = ...
+    dimension=[3],
 )
 
 
@@ -198,59 +166,51 @@ equipment1 = df.add_equipment(
     "EQ1",
     status=1,
     eq_type=enums.EquipmentType.TOOL,
-    serial_number='1239-12312',
-    weight={'value': 123.2, 'units': enums.Unit.KILOGRAM},  # specifying value and units in one line - dict version
-    length=AttrSetup(2, enums.Unit.METER)  # specifying value and units in one line - AttrSetup version
+    serial_number="1239-12312",
+    weight={
+        "value": 123.2,
+        "units": enums.Unit.KILOGRAM,
+    },  # specifying value and units in one line - dict version
+    length=AttrSetup(
+        2, enums.Unit.METER
+    ),  # specifying value and units in one line - AttrSetup version
 )
 
 # 'value' and 'units' can also be added later to the created object.
 equipment2 = df.add_equipment(
-    "EQ2",
-    location=enums.EquipmentLocation.WELL,
-    trademark_name='Some trademark TM'
+    "EQ2", location=enums.EquipmentLocation.WELL, trademark_name="Some trademark TM"
 )
 equipment2.hole_size.value = 23.5
 equipment2.hole_size.units = enums.Unit.INCH
 
-equipment3 = df.add_equipment('EQ3')
+equipment3 = df.add_equipment("EQ3")
 equipment3.status.value = 0
 
 
 # tool - using equipment, channels, and parameters
 tool1 = df.add_tool(
-    'TOOL1',
+    "TOOL1",
     status=1,
     parts=(equipment1, equipment2),
     channels=(ch5, ch6),
-    description='...'
+    description="...",
 )
 tool2 = df.add_tool(
-    'TOOL2',
+    "TOOL2",
     parameters=(parameter1, parameter2),
     channels=(ch1, ch2, ch3),
-    parts=(equipment1,)
+    parts=(equipment1,),
 )
 
 
 # computation - using axis, zones, tool, and long name
 computation1 = df.add_computation(
-    'CMPT1',
-    axis=[ax1],
-    source=tool2,
-    zones=(zone1, zone2, zone3),
-    dimension=[2]
+    "CMPT1", axis=[ax1], source=tool2, zones=(zone1, zone2, zone3), dimension=[2]
 )
 computation1.values.value = [[1, 2], [1, 3], [1, 4]]
 
-computation2 = df.add_computation(
-    'CMPT2',
-    values=[2.3, 11.12312, 2231213.22]
-)
-computation3 = df.add_computation(
-    'CMPT3',
-    values=[3.14],
-    long_name=long_name3
-)
+computation2 = df.add_computation("CMPT2", values=[2.3, 11.12312, 2231213.22])
+computation3 = df.add_computation("CMPT3", values=[3.14], long_name=long_name3)
 
 
 # process - using channels, computations, and parameters
@@ -260,57 +220,52 @@ process1 = df.add_process(
     output_channels=(ch4,),
     input_computations=(computation1,),
     output_computations=(computation2, computation3),
-    properties=[enums.Property.AVERAGED, enums.Property.LOCALLY_DEFINED]
+    properties=[enums.Property.AVERAGED, enums.Property.LOCALLY_DEFINED],
 )
 
 
 # calibration coefficient
 coef1 = df.add_calibration_coefficient(
-    'CC1',
-    label='Gain',
+    "CC1",
+    label="Gain",
     coefficients=[100.1, 100.2],
     references=[122, 123],
     plus_tolerances=[2, 2.5],
-    minus_tolerances=[3, 2.4]
+    minus_tolerances=[3, 2.4],
 )
-coef2 = df.add_calibration_coefficient(
-    'CC2',
-    coefficients=[1.2, 2.2, 3.4]
-)
-coef3 = df.add_calibration_coefficient(
-    'CC3',
-    coefficients=[2]
-)
+coef2 = df.add_calibration_coefficient("CC2", coefficients=[1.2, 2.2, 3.4])
+coef3 = df.add_calibration_coefficient("CC3", coefficients=[2])
 
 
 # calibration measurement - use Axis and Channel
 cmeas1 = df.add_calibration_measurement(
-    'CM1',
+    "CM1",
     phase=enums.CalibrationMeasurementPhase.BEFORE,
-    measurement_type='Plus',
+    measurement_type="Plus",
     axis=ax1,
     measurement_source=ch1,
     measurement=[2.1, 2.5, 2.4],
     sample_count=3,
     begin_time=15,
-    standard=[20, 25]
+    standard=[20, 25],
 )
 cmeas2 = df.add_calibration_measurement(
-    'CM2',
+    "CM2",
     measurement_source=ch5,
     measurement=[30, 40, 55, 61],
-    begin_time=datetime.now() - timedelta(hours=20)
+    begin_time=datetime.now() - timedelta(hours=20),
 )
 
 
 # calibration - using calibration coefficient & measurement, channels, and parameters
 calibration1 = df.add_calibration(
-    'CALIB-1', calibrated_channels=(ch4,),
+    "CALIB-1",
+    calibrated_channels=(ch4,),
     uncalibrated_channels=(ch1, ch5),
     coefficients=(coef1, coef2, coef3),
     measurements=(cmeas1, cmeas2),
     parameters=(parameter2,),
-    method='Two-point linear'
+    method="Two-point linear",
 )
 
 # well reference point
@@ -318,8 +273,8 @@ wrp = df.add_well_reference_point(
     "WELL-REF",
     coordinate_1_name="Latitude",
     coordinate_1_value=40.34,
-    coordinate_2_name='Longitude',
-    coordinate_2_value=23.4232
+    coordinate_2_name="Longitude",
+    coordinate_2_value=23.4232,
 )
 
 
@@ -332,86 +287,40 @@ wrp = df.add_well_reference_point(
 
 # message
 message1 = df.add_message(
-    'MSG1',
-    text=["Some message", "part 2 of the message"],
-    time=datetime.now()
+    "MSG1", text=["Some message", "part 2 of the message"], time=datetime.now()
 )
-message2 = df.add_message(
-    "MSG2",
-    text=["You have a message"],
-    message_type="Command"
-)
+message2 = df.add_message("MSG2", text=["You have a message"], message_type="Command")
 message3 = df.add_message(
-    "MSG3",
-    vertical_depth=213.1,
-    text=["More", "text"],
-    time=121.22
+    "MSG3", vertical_depth=213.1, text=["More", "text"], time=121.22
 )
 
 
 # comment
 comment1 = df.add_comment(
-    "CMT1",
-    text=["Part 1 of the comment", "Part 2 of the comment"]
+    "CMT1", text=["Part 1 of the comment", "Part 2 of the comment"]
 )
-comment2 = df.add_comment(
-    "COMMENT-2",
-    text=["Short comment"]
-)
+comment2 = df.add_comment("COMMENT-2", text=["Short comment"])
 
 
 # no-format & no-format frame data
 no_format1 = df.add_no_format(
-    "NF1",
-    consumer_name="Some consumer",
-    description="Some description"
+    "NF1", consumer_name="Some consumer", description="Some description"
 )
-no_format2 = df.add_no_format(
-    "NF2",
-    description="XYZ"
-)
-ndf1_1 = df.add_no_format_frame_data(
-    no_format1,
-    data="XYZ"
-)
-nfd1_2 = df.add_no_format_frame_data(
-    no_format1,
-    data="ABC"
-)
-nfd2_1 = df.add_no_format_frame_data(
-    no_format2,
-    data="Lorem ipsum"
-)
+no_format2 = df.add_no_format("NF2", description="XYZ")
+ndf1_1 = df.add_no_format_frame_data(no_format1, data="XYZ")
+nfd1_2 = df.add_no_format_frame_data(no_format1, data="ABC")
+nfd2_1 = df.add_no_format_frame_data(no_format2, data="Lorem ipsum")
 
 
 # groups
 group1 = df.add_group(
-    "DEPTH ZONES",
-    description='Zones describing depth',
-    object_list=(zone1, zone3)
+    "DEPTH ZONES", description="Zones describing depth", object_list=(zone1, zone3)
 )
-group2 = df.add_group(
-    "MESSAGES",
-    object_list=(message1, message2, message3)
-)
-group3 = df.add_group(
-    "INDEX CHANNELS",
-    object_list=(ch1, ch5)
-)
-df.add_group(
-    "ALL CHANNELS",
-    object_list=(ch2, ch3, ch4, ch6),
-    group_list=(group3,)
-)
-group5 = df.add_group(
-    "GROUPS",
-    group_list=(group1, group2, group3)
-)
+group2 = df.add_group("MESSAGES", object_list=(message1, message2, message3))
+group3 = df.add_group("INDEX CHANNELS", object_list=(ch1, ch5))
+df.add_group("ALL CHANNELS", object_list=(ch2, ch3, ch4, ch6), group_list=(group3,))
+group5 = df.add_group("GROUPS", group_list=(group1, group2, group3))
 
 
 # write the file
-df.write(
-    './tmp.DLIS',
-    input_chunk_size=20,
-    output_chunk_size=2**13
-)
+df.write("./tmp.DLIS", input_chunk_size=20, output_chunk_size=2**13)

--- a/examples/create_synth_dlis_variable_data.py
+++ b/examples/create_synth_dlis_variable_data.py
@@ -71,26 +71,27 @@ def create_dlis_spec(n_points: int, n_images: int = 0, n_cols: int = 128, time_b
     """
 
     df = DLISFile()
-    df.add_origin("ORIGIN")
+    lf = df.add_logical_file()
+    lf.add_origin("ORIGIN")
 
     if time_based:
         logger.debug("Creating time dataset")
-        index = df.add_channel("TIME", data=0.5 * np.arange(n_points))
+        index = lf.add_channel("TIME", data=0.5 * np.arange(n_points))
         index_type = enums.FrameIndexType.NON_STANDARD
     else:
         logger.debug("Creating depth dataset")
-        index = df.add_channel('DEPTH', data=2500 + 0.1 * np.arange(n_points))
+        index = lf.add_channel('DEPTH', data=2500 + 0.1 * np.arange(n_points))
         index_type = enums.FrameIndexType.BOREHOLE_DEPTH
 
     channels = [index]
 
     for i in range(n_images):
         logger.debug(f"Creating image dataset {i+1}/{n_images}")
-        ch = df.add_channel(
+        ch = lf.add_channel(
             f'IMAGE{i}', data=make_image(n_points, n_cols, divider=int(10 + (n_cols - 11) * np.random.rand())))
         channels.append(ch)
 
-    df.add_frame("MAIN-FRAME", channels=channels, index_type=index_type)
+    lf.add_frame("MAIN-FRAME", channels=channels, index_type=index_type)
 
     return df
 

--- a/src/dliswriter/__init__.py
+++ b/src/dliswriter/__init__.py
@@ -1,4 +1,4 @@
-from dliswriter.file.file import DLISFile
+from dliswriter.file.file import DLISFile, LogicalFile
 from dliswriter.logical_record.core.eflr import EFLRSet, EFLRItem, AttrSetup
 from dliswriter.logical_record.core.attribute import Attribute
 from dliswriter.logical_record.misc.storage_unit_label import StorageUnitLabel

--- a/src/dliswriter/file/eflr_sets_dict.py
+++ b/src/dliswriter/file/eflr_sets_dict.py
@@ -33,7 +33,7 @@ class EFLRSetsDict(defaultdict):
 
         self[eflr_set.__class__][eflr_set.set_name] = eflr_set
 
-    def try_add_set(self, eflr_set: EFLRSet) -> None:
+    def try_add_set(self, eflr_set: EFLRSet) -> bool:
         """Try to register a new EFLRSet instance in the structure. Return True on success, False otherwise."""
 
         if eflr_set.set_name in self[eflr_set.__class__]:

--- a/src/dliswriter/file/eflr_sets_dict.py
+++ b/src/dliswriter/file/eflr_sets_dict.py
@@ -33,6 +33,15 @@ class EFLRSetsDict(defaultdict):
 
         self[eflr_set.__class__][eflr_set.set_name] = eflr_set
 
+    def try_add_set(self, eflr_set: EFLRSet) -> None:
+        """Try to register a new EFLRSet instance in the structure. Return True on success, False otherwise."""
+
+        if eflr_set.set_name in self[eflr_set.__class__]:
+            return False
+        else:
+            self[eflr_set.__class__][eflr_set.set_name] = eflr_set
+            return True
+
     def get_or_make_set(self, eflr_set_type: type[AnyEFLRSet], set_name: Optional[str] = None) -> AnyEFLRSet:
         """Given an EFLRSet subclass and name, either retrieve a relevant EFLRSet from the structure or create it.
 

--- a/src/dliswriter/file/file.py
+++ b/src/dliswriter/file/file.py
@@ -10,8 +10,17 @@ from datetime import timedelta, datetime
 import logging
 
 from dliswriter.utils.source_data_wrappers import DictDataWrapper, SourceDataWrapper
-from dliswriter.utils.internal.types import (numpy_dtype_type, number_type, dtime_or_number_type, list_of_values_type,
-                                             file_name_type, data_form_type, ListOrTuple, NestedList, AttrDict)
+from dliswriter.utils.internal.types import (
+    numpy_dtype_type,
+    number_type,
+    dtime_or_number_type,
+    list_of_values_type,
+    file_name_type,
+    data_form_type,
+    ListOrTuple,
+    NestedList,
+    AttrDict,
+)
 from dliswriter.utils.internal.sized_generator import SizedGenerator
 from dliswriter.utils import enums
 from dliswriter.logical_record.core.eflr import EFLRItem, AttrSetup
@@ -23,42 +32,224 @@ from dliswriter.file.writer import DLISWriter
 from dliswriter.file.eflr_sets_dict import EFLRSetsDict
 from dliswriter.configuration import global_config
 
-
 logger = logging.getLogger(__name__)
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 AttrSetupType = Union[T, AttrDict, AttrSetup]
 OptAttrSetupType = Optional[AttrSetupType[T]]
 
 
+def _set_up_sul_or_fh(item_class: type[T], item: Optional[T], **kwargs: Any) -> T:
+
+    if item is not None:
+        if not isinstance(item, item_class):
+            raise TypeError(
+                f"Expected a {item_class.__name__}, got {type(item)}: {item}"
+            )
+        logger.debug(f"Using the provided {item_class.__name__} instance")
+
+    else:
+        logger.debug(f"Creating a new {item_class.__name__} instance")
+        item = item_class(**kwargs)
+
+    logger.debug(f"{item_class.__name__} for the file: {repr(item)}")
+    return item
+
+
+def raise_or_warn(message: str) -> None:
+    """If high-compatibility mode is on, raise a RuntimeError with given message. Otherwise, put it in the logs."""
+
+    if global_config.high_compat_mode:
+        raise RuntimeError(message)
+    logger.warning(message)
+
+
 class DLISFile:
-    """Define the structure and contents of a DLIS and create a file based on the provided information."""
+    """DLIS file. Contains the list of the logical files, the Storage Unit Label and the writing routines"""
 
     def __init__(
-            self,
-            storage_unit_label: Optional[StorageUnitLabel] = None,
-            file_header: Optional[eflr_types.FileHeaderItem] = None,
-            set_identifier: str = "MAIN-STORAGE-UNIT",
-            sul_sequence_number: int = 1,
-            max_record_length: int = 8192,
-            fh_id: str = "FILE-HEADER",
-            fh_identifier: str = "0",
-            fh_sequence_number: int = 1
+        self,
+        storage_unit_label: Optional[StorageUnitLabel] = None,
+        set_identifier: str = "MAIN-STORAGE-UNIT",
+        sul_sequence_number: int = 1,
+        max_record_length: int = 8192,
     ):
-        """Initialise DLISFile.
+        self.logical_files: list[LogicalFile] = []
+
+        self._sul: StorageUnitLabel = _set_up_sul_or_fh(
+            item_class=StorageUnitLabel,
+            item=storage_unit_label,
+            set_identifier=set_identifier,
+            sequence_number=sul_sequence_number,
+            max_record_length=max_record_length,
+        )
+
+        self._eflr_sets = EFLRSetsDict()
+
+    @property
+    def storage_unit_label(self) -> StorageUnitLabel:
+        """Storage Unit Label of the DLIS."""
+
+        return self._sul
+
+    def add_logical_file(
+        self,
+        file_header: Optional[eflr_types.FileHeaderItem] = None,
+        fh_id: str = "FILE-HEADER",
+        fh_identifier: str = "0",
+        fh_sequence_number: int = 1,
+    ) -> "LogicalFile":
+        lf = LogicalFile(
+            physical_file=self,
+            file_header=file_header,
+            fh_id=fh_id,
+            fh_identifier=fh_identifier,
+            fh_sequence_number=fh_sequence_number,
+        )
+        self.logical_files.append(lf)
+        return lf
+
+    def generate_logical_records(
+        self,
+        chunk_size: Optional[int],
+        data: Optional[data_form_type] = None,
+        **kwargs: Any,
+    ) -> SizedGenerator:
+        """Iterate over all logical records defined in the file.
+
+        Yields: EFLR and IFLR objects defined for the file.
+
+        Note: Storage Unit Label should be added to the file separately before adding other records.
+        """
+
+        multi_frame_data_objects: list[list[MultiFrameData]] = []
+        frame_items: list[Generator[eflr_types.FrameItem, None, None]] = []
+
+        for idx_lf, logical_file in enumerate(self.logical_files):
+
+            frame_items.append(
+                list(
+                    logical_file._eflr_sets.get_all_items_for_set_type(
+                        eflr_types.FrameSet
+                    )
+                )
+            )
+
+            multi_frame_data_objects.append(
+                [
+                    logical_file._make_multi_frame_data(
+                        fr, chunk_size=chunk_size, data=data, **kwargs
+                    )
+                    for fr in frame_items[idx_lf]
+                ]
+            )
+
+        n = 0
+        for eflr_set_type in self._eflr_sets:
+            n += len(list(self._eflr_sets.get_all_items_for_set_type(eflr_set_type)))
+
+        for idx_lf, logical_file in enumerate(self.logical_files):
+            for mfd in multi_frame_data_objects[idx_lf]:
+                n += len(mfd)
+            n += len(logical_file._no_format_frame_data)
+
+        def generator() -> Generator:
+            """Define a generator yielding logical records to be put in the file."""
+
+            for idx_lf, logical_file in enumerate(self.logical_files):
+                if logical_file.defining_origin is None:
+                    raise RuntimeError(
+                        f"No Origin defined for the {idx_lf}-th logical file"
+                    )
+
+                yield logical_file.file_header_item.parent
+
+                yield from logical_file._eflr_sets[eflr_types.OriginSet].values()
+
+                for set_type, set_dict in logical_file._eflr_sets.items():
+                    if set_type not in (eflr_types.FileHeaderSet, eflr_types.OriginSet):
+                        yield from set_dict.values()
+
+                yield from logical_file._no_format_frame_data
+
+                for multi_frame_data in multi_frame_data_objects[idx_lf]:
+                    yield from multi_frame_data
+
+        return SizedGenerator(generator(), size=n)
+
+    def write(
+        self,
+        dlis_file_name: file_name_type,
+        input_chunk_size: Optional[int] = None,
+        output_chunk_size: Optional[number_type] = 2**32,
+        data: Optional[data_form_type] = None,
+        from_idx: int = 0,
+        to_idx: Optional[int] = None,
+    ) -> None:
+        """Create a DLIS file form the current specifications.
 
         Args:
-            storage_unit_label  :   An instance of StorageUnitLabel. If not provided, a new instance will be created
-                                    based on other provided arguments and/or defaults.
+            dlis_file_name          :   Name of the file to be created.
+            input_chunk_size        :   Size of the chunks (in rows) in which input data will be loaded to be processed.
+            output_chunk_size       :   Size of the buffers accumulating file bytes before file write action is called.
+            data                    :   Data for channels - if not specified when channels were added.
+            from_idx                :   Index from which the data should be loaded (or number of initial rows
+                                        to ignore).
+            to_idx                  :   Index up to which data should be loaded.
+        """
+
+        def timed_func() -> None:
+            """Perform the action of creating a DLIS file.
+
+            This function is used in a timeit call to time the file creation.
+            """
+
+            for lf in self.logical_files:
+                lf.check_objects()
+
+            logical_records = self.generate_logical_records(
+                chunk_size=input_chunk_size,
+                data=data,
+                from_idx=from_idx,
+                to_idx=to_idx,
+            )
+
+            writer = DLISWriter(
+                dlis_file_name,
+                visible_record_length=self.storage_unit_label.max_record_length,
+            )
+            writer.write_storage_unit_label(self.storage_unit_label)
+            writer.write_logical_records(
+                logical_records, output_chunk_size=output_chunk_size
+            )
+
+        exec_time = timeit(timed_func, number=1)
+        logger.info(
+            f"DLIS file created in {timedelta(seconds=exec_time)} ({exec_time} seconds)"
+        )
+
+
+class LogicalFile:
+    """Define the structure and contents of a DLIS Logical File. The Logical File constitutes the DLIS logical
+    format ("The view of DLIS data that is completely independent of any physical mapping" - rp66v1). A DLIS file
+    can have one or more Logical Files, and these logical files are mutually independent
+    """
+
+    def __init__(
+        self,
+        physical_file: DLISFile,
+        file_header: Optional[eflr_types.FileHeaderItem] = None,
+        fh_id: str = "FILE-HEADER",
+        fh_identifier: str = "0",
+        fh_sequence_number: int = 1,
+    ):
+        """Initialise LogicalFile.
+
+        Args:
+            physical_file       :   The DLIS file (storage unit, in rp66v1 terms) that this logical file belongs to
             file_header         :   An instance of FileHeaderItem. If not provided, a new instance will be created
                                     based on other provided arguments and/or defaults.
-            set_identifier      :   Used to create a StorageUnitLabel. ID of the storage set.
-            sul_sequence_number :   Used to create a StorageUnitLabel. Indicates the order in which the current
-                                    Storage Unit appears in a Storage Set.
-            max_record_length   :   Used to create a StorageUnitLabel. Maximum length of each visible record.
-                                    Cannot exceed 16384.
-                                    See  # http://w3.energistics.org/rp66/v1/rp66v1_sec2.html#2_3_6_5
             fh_id               :   Used to create a FileHeaderItem.
                                     '[A] descriptive identification of the Logical File', max 65 characters long.
             fh_identifier       :   Used to create a FileHeaderItem.
@@ -69,61 +260,44 @@ class DLISFile:
                                     A positive integer of max 10 digits.
         """
 
-        self._sul: StorageUnitLabel = self._set_up_sul_or_fh(
-            item_class=StorageUnitLabel,
-            item=storage_unit_label,
-            set_identifier=set_identifier,
-            sequence_number=sul_sequence_number,
-            max_record_length=max_record_length
-        )
+        self.physical_file = physical_file
 
-        file_header_item: eflr_types.FileHeaderItem = self._set_up_sul_or_fh(
-            item_class=eflr_types.FileHeaderItem,
-            item=file_header,
-            header_id=fh_id,
-            identifier=fh_identifier,
-            sequence_number=fh_sequence_number,
-            parent=eflr_types.FileHeaderSet()
-        )
-
+        # Having a _eflr_sets also in the logical file allows for checks that don't relate to the whole DLIS file
         self._eflr_sets = EFLRSetsDict()
-        self._eflr_sets.add_set(file_header_item.parent)
+
+        fh_set = eflr_types.FileHeaderSet()
+
+        # fh_set.set_name = fh_identifier
+        # FIXME - Setting the name of the file header somehow corrupts the output DLIS file. This is probably related to the Issue #14
+        # And because of that it's problematic to add the fh_set to the self._eflr_sets and physical_file._eflr_sets, now that we
+        # have multiple logical files, each one having their header. This is why we have file_header_item as an attribute, as we see below:
+
+        if file_header is not None:
+            self.file_header_item: eflr_types.FileHeaderItem = file_header
+        else:
+            self.file_header_item: eflr_types.FileHeaderItem = _set_up_sul_or_fh(
+                item_class=eflr_types.FileHeaderItem,
+                item=file_header,
+                header_id=fh_id,
+                identifier=fh_identifier,
+                sequence_number=fh_sequence_number,
+                parent=fh_set,  # file_header.parent
+            )
 
         self._data_dict: dict[str, np.ndarray] = {}
         self._max_dataset_copy = 1000
 
         self._no_format_frame_data: list[NoFormatFrameData] = []
 
-    @staticmethod
-    def _set_up_sul_or_fh(item_class: type[T], item: Optional[T], **kwargs: Any) -> T:
-
-        if item is not None:
-            if not isinstance(item, item_class):
-                raise TypeError(f"Expected a {item_class.__name__}, got {type(item)}: {item}")
-            logger.debug(f"Using the provided {item_class.__name__} instance")
-
-        else:
-            logger.debug(f"Creating a new {item_class.__name__} instance")
-            item = item_class(**kwargs)
-
-        logger.debug(f"{item_class.__name__} for the file: {repr(item)}")
-        return item
-
-    @property
-    def storage_unit_label(self) -> StorageUnitLabel:
-        """Storage Unit Label of the DLIS."""
-
-        return self._sul
-
     @property
     def file_header(self) -> eflr_types.FileHeaderItem:
-        """File header of the DLIS."""
+        """File header of this Logical File"""
 
-        return list(self._eflr_sets.get_all_items_for_set_type(eflr_types.FileHeaderSet))[0]
+        return self.file_header_item
 
     @property
     def defining_origin(self) -> Union[eflr_types.OriginItem, None]:
-        """First Origin of the DLIS, describing the circumstances under which the file was created."""
+        """First Origin of this Logical File, describing the circumstances under which it was created."""
 
         origins: list[eflr_types.OriginItem] = list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginSet))
         return origins[0] if origins else None
@@ -131,7 +305,7 @@ class DLISFile:
     @property
     def default_origin_reference(self) -> Union[int, None]:
         if origin := self.defining_origin:
-            return origin.file_set_number.value  # type: ignore  # this is an int or None, but mypy doesn't know
+            return origin.origin_reference  # type: ignore  # this is an int or None, but mypy doesn't know
         return None
 
     @property
@@ -146,14 +320,20 @@ class DLISFile:
 
         return list(self._eflr_sets.get_all_items_for_set_type(eflr_types.FrameSet))
 
+    @property
+    def origins(self) -> list[eflr_types.OriginItem]:
+        """Channels defined for the DLIS."""
+
+        return list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginItem))
+
     def add_axis(
-            self,
-            name: str,
-            axis_id: OptAttrSetupType[str] = None,
-            coordinates: OptAttrSetupType[list_of_values_type] = None,
-            spacing: OptAttrSetupType[number_type] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        axis_id: OptAttrSetupType[str] = None,
+        coordinates: OptAttrSetupType[list_of_values_type] = None,
+        spacing: OptAttrSetupType[number_type] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.AxisItem:
         """Define an axis (AxisItem) and add it to the DLIS.
 
@@ -176,31 +356,43 @@ class DLISFile:
                                     of successive coordinate values along the axis, and the first coordinate value
                                     is assumed to be zero (0).'
             set_name            :   Name of the AxisSet this axis should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.AxisSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         ax = eflr_types.AxisItem(
             name=name,
             axis_id=axis_id,
             coordinates=coordinates,
             spacing=spacing,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.AxisSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return ax
 
     def add_calibration(
-            self,
-            name: str,
-            calibrated_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            uncalibrated_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            coefficients: OptAttrSetupType[ListOrTuple[eflr_types.CalibrationCoefficientItem]] = None,
-            measurements: OptAttrSetupType[ListOrTuple[eflr_types.CalibrationMeasurementItem]] = None,
-            parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
-            method: OptAttrSetupType[str] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        calibrated_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]
+        ] = None,
+        uncalibrated_channels: OptAttrSetupType[
+            ListOrTuple[eflr_types.ChannelItem]
+        ] = None,
+        coefficients: OptAttrSetupType[
+            ListOrTuple[eflr_types.CalibrationCoefficientItem]
+        ] = None,
+        measurements: OptAttrSetupType[
+            ListOrTuple[eflr_types.CalibrationMeasurementItem]
+        ] = None,
+        parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
+        method: OptAttrSetupType[str] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.CalibrationItem:
         """Define a calibration item and add it to the DLIS.
 
@@ -233,11 +425,16 @@ class DLISFile:
                                         by the Calibrated-Channels Attribute. (...) For the simple model described
                                         earlier [gain and offset calibration], the Method might be "Two-Point-Linear".'
             set_name                :   Name of the CalibrationSet this calibration should be added to.
-            origin_reference        :   file_set_number of the Origin this record belongs to.
+            origin_reference        :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured calibration object.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.CalibrationSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         c = eflr_types.CalibrationItem(
             name=name,
@@ -247,22 +444,22 @@ class DLISFile:
             measurements=measurements,
             parameters=parameters,
             method=method,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.CalibrationSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return c
 
     def add_calibration_coefficient(
-            self,
-            name: str,
-            label: OptAttrSetupType[str] = None,
-            coefficients: OptAttrSetupType[list[number_type]] = None,
-            references: OptAttrSetupType[list[number_type]] = None,
-            plus_tolerances: OptAttrSetupType[list[number_type]] = None,
-            minus_tolerances: OptAttrSetupType[list[number_type]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        label: OptAttrSetupType[str] = None,
+        coefficients: OptAttrSetupType[list[number_type]] = None,
+        references: OptAttrSetupType[list[number_type]] = None,
+        plus_tolerances: OptAttrSetupType[list[number_type]] = None,
+        minus_tolerances: OptAttrSetupType[list[number_type]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.CalibrationCoefficientItem:
         """Define a calibration coefficient object and add it to the DLIS.
 
@@ -304,7 +501,7 @@ class DLISFile:
                                     when its reference is 1.0 and its minus tolerance is 0.1.
                                     It is out of tolerance when its reference is 1.0 and its minus tolerance is 0.01.'
             set_name            :   Name of the CorrelationCoefficientSet this item should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Notes:
             Attributes 'coefficients', 'references', 'plus_tolerances', and 'minus_tolerances' must have the same number
@@ -314,6 +511,11 @@ class DLISFile:
             A configured calibration coefficient item.
         """
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.CalibrationCoefficientSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
         c = eflr_types.CalibrationCoefficientItem(
             name=name,
             label=label,
@@ -321,32 +523,32 @@ class DLISFile:
             references=references,
             plus_tolerances=plus_tolerances,
             minus_tolerances=minus_tolerances,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.CalibrationCoefficientSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return c
 
     def add_calibration_measurement(
-            self,
-            name: str,
-            phase: OptAttrSetupType[Union[str, enums.CalibrationMeasurementPhase]] = None,
-            measurement_source: OptAttrSetupType[EFLRItem] = None,
-            measurement_type: OptAttrSetupType[str] = None,
-            dimension: OptAttrSetupType[list[int]] = None,
-            axis: OptAttrSetupType[eflr_types.AxisItem] = None,
-            measurement: OptAttrSetupType[NestedList[number_type]] = None,
-            sample_count: OptAttrSetupType[int] = None,
-            maximum_deviation: OptAttrSetupType[NestedList[number_type]] = None,
-            standard_deviation: OptAttrSetupType[NestedList[number_type]] = None,
-            begin_time: OptAttrSetupType[dtime_or_number_type] = None,
-            duration: OptAttrSetupType[number_type] = None,
-            reference: OptAttrSetupType[NestedList[number_type]] = None,
-            standard: OptAttrSetupType[NestedList[number_type]] = None,
-            plus_tolerance: OptAttrSetupType[NestedList[number_type]] = None,
-            minus_tolerance: OptAttrSetupType[NestedList[number_type]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        phase: OptAttrSetupType[Union[str, enums.CalibrationMeasurementPhase]] = None,
+        measurement_source: OptAttrSetupType[EFLRItem] = None,
+        measurement_type: OptAttrSetupType[str] = None,
+        dimension: OptAttrSetupType[list[int]] = None,
+        axis: OptAttrSetupType[eflr_types.AxisItem] = None,
+        measurement: OptAttrSetupType[NestedList[number_type]] = None,
+        sample_count: OptAttrSetupType[int] = None,
+        maximum_deviation: OptAttrSetupType[NestedList[number_type]] = None,
+        standard_deviation: OptAttrSetupType[NestedList[number_type]] = None,
+        begin_time: OptAttrSetupType[dtime_or_number_type] = None,
+        duration: OptAttrSetupType[number_type] = None,
+        reference: OptAttrSetupType[NestedList[number_type]] = None,
+        standard: OptAttrSetupType[NestedList[number_type]] = None,
+        plus_tolerance: OptAttrSetupType[NestedList[number_type]] = None,
+        minus_tolerance: OptAttrSetupType[NestedList[number_type]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.CalibrationMeasurementItem:
         """Define a calibration measurement item and add it to the DLIS.
 
@@ -435,11 +637,16 @@ class DLISFile:
                                     is within tolerance when its reference is 350 and its minus tolerance is 5.
                                     It is out of tolerance when its reference is 400 and its minus tolerance is 50.'
             set_name            :   Name of the CorrelationMeasurementSet this measurement should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured CalibrationMeasurementItem instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.CalibrationMeasurementSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         m = eflr_types.CalibrationMeasurementItem(
             name=name,
@@ -458,29 +665,29 @@ class DLISFile:
             standard=standard,
             plus_tolerance=plus_tolerance,
             minus_tolerance=minus_tolerance,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.CalibrationMeasurementSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return m
 
     def add_channel(
-            self,
-            name: str,
-            data: Optional[np.ndarray] = None,
-            dataset_name: Optional[str] = None,
-            cast_dtype: Optional[numpy_dtype_type] = None,
-            long_name: OptAttrSetupType[Union[eflr_types.LongNameItem, str]] = None,
-            dimension: OptAttrSetupType[Union[int, list[int]]] = None,
-            element_limit: OptAttrSetupType[Union[int, list[int]]] = None,
-            properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
-            units: OptAttrSetupType[Union[str, enums.Unit]] = None,
-            axis: OptAttrSetupType[eflr_types.AxisItem] = None,
-            minimum_value: OptAttrSetupType[float] = None,
-            maximum_value: OptAttrSetupType[float] = None,
-            source: OptAttrSetupType[EFLRItem] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        data: Optional[np.ndarray] = None,
+        dataset_name: Optional[str] = None,
+        cast_dtype: Optional[numpy_dtype_type] = None,
+        long_name: OptAttrSetupType[Union[eflr_types.LongNameItem, str]] = None,
+        dimension: OptAttrSetupType[Union[int, list[int]]] = None,
+        element_limit: OptAttrSetupType[Union[int, list[int]]] = None,
+        properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
+        units: OptAttrSetupType[Union[str, enums.Unit]] = None,
+        axis: OptAttrSetupType[eflr_types.AxisItem] = None,
+        minimum_value: OptAttrSetupType[float] = None,
+        maximum_value: OptAttrSetupType[float] = None,
+        source: OptAttrSetupType[EFLRItem] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ChannelItem:
         """Define a channel (ChannelItem) and add it to the DLIS.
 
@@ -516,7 +723,7 @@ class DLISFile:
             source              :   '[A] reference to another Object that describes the immediate source of the Channel,
                                     for example, a TOOL, PROCESS, SPLICE, or CALIBRATION Object.'
             set_name            :   Name of the ChannelSet this Channel should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured ChannelItem instance, which is already added to the DLIS (but not to any frame).
@@ -526,6 +733,12 @@ class DLISFile:
             raise ValueError(f"Expected a numpy.ndarray, got a {type(data)}: {data}")
 
         dataset_name = self._get_unique_dataset_name(channel_name=name, dataset_name=dataset_name)
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ChannelSet, set_name=set_name
+        )
+
+        prnt = self._eflr_sets.try_add_set(parent)
 
         ch = eflr_types.ChannelItem(
             name,
@@ -540,8 +753,8 @@ class DLISFile:
             minimum_value=minimum_value,
             maximum_value=maximum_value,
             source=source,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ChannelSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         if data is not None:
@@ -573,10 +786,11 @@ class DLISFile:
         return n
 
     def add_comment(
-            self, name: str,
-            text: OptAttrSetupType[list[str]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        text: OptAttrSetupType[list[str]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.CommentItem:
         """Create a comment item and add it to the DLIS.
 
@@ -584,33 +798,38 @@ class DLISFile:
             name                :   Name of the object.
             text                :   Content of the comment.
             set_name            :   Name of the CommentSet this comment should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured comment item.
         """
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.CommentSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
         c = eflr_types.CommentItem(
             name=name,
             text=text,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.CommentSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return c
 
     def add_computation(
-            self,
-            name: str,
-            long_name: OptAttrSetupType[Union[str, eflr_types.LongNameItem]] = None,
-            properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
-            dimension: OptAttrSetupType[list[int]] = None,
-            axis: OptAttrSetupType[ListOrTuple[eflr_types.AxisItem]] = None,
-            zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
-            values: OptAttrSetupType[NestedList[number_type]] = None,
-            source: OptAttrSetupType[EFLRItem] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        long_name: OptAttrSetupType[Union[str, eflr_types.LongNameItem]] = None,
+        properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
+        dimension: OptAttrSetupType[list[int]] = None,
+        axis: OptAttrSetupType[ListOrTuple[eflr_types.AxisItem]] = None,
+        zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
+        values: OptAttrSetupType[NestedList[number_type]] = None,
+        source: OptAttrSetupType[EFLRItem] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ComputationItem:
         """Create a computation item and add it to the DLIS.
 
@@ -645,11 +864,16 @@ class DLISFile:
             source              :   '[A] reference to another Object that describes the immediate source of the
                                     Computation, for example, a PROCESS Object.'
             set_name            :   Name of the ComputationSet this computation should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured computation item.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ComputationSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         c = eflr_types.ComputationItem(
             name=name,
@@ -660,34 +884,34 @@ class DLISFile:
             zones=zones,
             values=values,
             source=source,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ComputationSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return c
 
     def add_equipment(
-            self,
-            name: str,
-            trademark_name: OptAttrSetupType[str] = None,
-            status: OptAttrSetupType[int] = None,
-            eq_type: OptAttrSetupType[Union[str, enums.EquipmentType]] = None,
-            serial_number: OptAttrSetupType[str] = None,
-            location: OptAttrSetupType[Union[str, enums.EquipmentLocation]] = None,
-            height: OptAttrSetupType[number_type] = None,
-            length: OptAttrSetupType[number_type] = None,
-            minimum_diameter: OptAttrSetupType[number_type] = None,
-            maximum_diameter: OptAttrSetupType[number_type] = None,
-            volume: OptAttrSetupType[number_type] = None,
-            weight: OptAttrSetupType[number_type] = None,
-            hole_size: OptAttrSetupType[number_type] = None,
-            pressure: OptAttrSetupType[number_type] = None,
-            temperature: OptAttrSetupType[number_type] = None,
-            vertical_depth: OptAttrSetupType[number_type] = None,
-            radial_drift: OptAttrSetupType[number_type] = None,
-            angular_drift: OptAttrSetupType[number_type] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        trademark_name: OptAttrSetupType[str] = None,
+        status: OptAttrSetupType[int] = None,
+        eq_type: OptAttrSetupType[Union[str, enums.EquipmentType]] = None,
+        serial_number: OptAttrSetupType[str] = None,
+        location: OptAttrSetupType[Union[str, enums.EquipmentLocation]] = None,
+        height: OptAttrSetupType[number_type] = None,
+        length: OptAttrSetupType[number_type] = None,
+        minimum_diameter: OptAttrSetupType[number_type] = None,
+        maximum_diameter: OptAttrSetupType[number_type] = None,
+        volume: OptAttrSetupType[number_type] = None,
+        weight: OptAttrSetupType[number_type] = None,
+        hole_size: OptAttrSetupType[number_type] = None,
+        pressure: OptAttrSetupType[number_type] = None,
+        temperature: OptAttrSetupType[number_type] = None,
+        vertical_depth: OptAttrSetupType[number_type] = None,
+        radial_drift: OptAttrSetupType[number_type] = None,
+        angular_drift: OptAttrSetupType[number_type] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.EquipmentItem:
         """Define an equipment item.
 
@@ -741,7 +965,7 @@ class DLISFile:
             radial_drift        :   Radial drift; see Notes below.
             angular_drift       :   Angular drift; see Notes below.
             set_name            :   Name of the EquipmentSet this equipment should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Notes:
             'The Vertical-Depth, Radial-Drift, and Angular-Drift Attributes specify the corresponding position
@@ -752,6 +976,11 @@ class DLISFile:
         Returns:
             A configured EquipmentItem instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.EquipmentSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         eq = eflr_types.EquipmentItem(
             name=name,
@@ -772,25 +1001,25 @@ class DLISFile:
             vertical_depth=vertical_depth,
             radial_drift=radial_drift,
             angular_drift=angular_drift,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.EquipmentSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return eq
 
     def add_frame(
-            self,
-            name: str,
-            channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]],
-            description: OptAttrSetupType[str] = None,
-            index_type: OptAttrSetupType[Union[str, enums.FrameIndexType]] = None,
-            direction: OptAttrSetupType[str] = None,
-            spacing: OptAttrSetupType[number_type] = None,
-            encrypted: OptAttrSetupType[int] = None,
-            index_min: OptAttrSetupType[number_type] = None,
-            index_max: OptAttrSetupType[number_type] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]],
+        description: OptAttrSetupType[str] = None,
+        index_type: OptAttrSetupType[Union[str, enums.FrameIndexType]] = None,
+        direction: OptAttrSetupType[str] = None,
+        spacing: OptAttrSetupType[number_type] = None,
+        encrypted: OptAttrSetupType[int] = None,
+        index_min: OptAttrSetupType[number_type] = None,
+        index_max: OptAttrSetupType[number_type] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.FrameItem:
         """Define a frame (FrameItem) and add it to the DLIS.
 
@@ -846,7 +1075,7 @@ class DLISFile:
                                     (i.e. 'the number of rows' in the data table in which Channels are
                                     the (sets of) columns).
             set_name            :   Name of the FrameSet this frame should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Note:
             Values: direction, spacing, index_min, and index_max are automatically determined if not provided.
@@ -866,6 +1095,11 @@ class DLISFile:
             raise TypeError(f"Expected a list of ChannelObject instances; "
                             f"got types: {', '.join(str(type(c)) for c in channels)}")
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.FrameSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
         fr = eflr_types.FrameItem(
             name,
             channels=channels,
@@ -876,20 +1110,20 @@ class DLISFile:
             encrypted=encrypted,
             index_min=index_min,
             index_max=index_max,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.FrameSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return fr
 
     def add_group(
-            self,
-            name: str,
-            description: OptAttrSetupType[str] = None,
-            object_list: OptAttrSetupType[ListOrTuple[EFLRItem]] = None,
-            group_list: OptAttrSetupType[ListOrTuple[eflr_types.GroupItem]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        description: OptAttrSetupType[str] = None,
+        object_list: OptAttrSetupType[ListOrTuple[EFLRItem]] = None,
+        group_list: OptAttrSetupType[ListOrTuple[eflr_types.GroupItem]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.GroupItem:
         """Create a group of EFLR items and add it to the DLIS.
 
@@ -904,43 +1138,48 @@ class DLISFile:
                                     are completely arbitrary.' The types of objects referenced by these groups might
                                     be different from other objects referenced by the current group.
             set_name            :   Name of the FrameSet this frame should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured group item.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.GroupSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         g = eflr_types.GroupItem(
             name=name,
             description=description,
             object_list=object_list,
             group_list=group_list,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.GroupSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=self.physical_file._eflr_sets.get_or_make_set(eflr_types.GroupSet, set_name=set_name),
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return g
 
     def add_long_name(
-            self,
-            name: str,
-            general_modifier: OptAttrSetupType[list[str]] = None,
-            quantity: OptAttrSetupType[str] = None,
-            quantity_modifier: OptAttrSetupType[list[str]] = None,
-            altered_form: OptAttrSetupType[str] = None,
-            entity: OptAttrSetupType[str] = None,
-            entity_modifier: OptAttrSetupType[list[str]] = None,
-            entity_number: OptAttrSetupType[str] = None,
-            entity_part: OptAttrSetupType[str] = None,
-            entity_part_number: OptAttrSetupType[str] = None,
-            generic_source: OptAttrSetupType[str] = None,
-            source_part: OptAttrSetupType[list[str]] = None,
-            source_part_number: OptAttrSetupType[list[str]] = None,
-            conditions: OptAttrSetupType[list[str]] = None,
-            standard_symbol: OptAttrSetupType[str] = None,
-            private_symbol: Optional[str] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        general_modifier: OptAttrSetupType[list[str]] = None,
+        quantity: OptAttrSetupType[str] = None,
+        quantity_modifier: OptAttrSetupType[list[str]] = None,
+        altered_form: OptAttrSetupType[str] = None,
+        entity: OptAttrSetupType[str] = None,
+        entity_modifier: OptAttrSetupType[list[str]] = None,
+        entity_number: OptAttrSetupType[str] = None,
+        entity_part: OptAttrSetupType[str] = None,
+        entity_part_number: OptAttrSetupType[str] = None,
+        generic_source: OptAttrSetupType[str] = None,
+        source_part: OptAttrSetupType[list[str]] = None,
+        source_part_number: OptAttrSetupType[list[str]] = None,
+        conditions: OptAttrSetupType[list[str]] = None,
+        standard_symbol: OptAttrSetupType[str] = None,
+        private_symbol: Optional[str] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.LongNameItem:
         """Create a Long Name item and add it to the DLIS.
 
@@ -987,11 +1226,16 @@ class DLISFile:
                                     are completely at the discretion of the Producer that is identified
                                     in the Origin Object associated with the Long Name Object.'
             set_name            :   Name of the LongNameSet this long name item should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured Long Name item.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.LongNameSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         ln = eflr_types.LongNameItem(
             name=name,
@@ -1010,24 +1254,24 @@ class DLISFile:
             conditions=conditions,
             standard_symbol=standard_symbol,
             private_symbol=private_symbol,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.LongNameSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return ln
 
     def add_message(
-            self,
-            name: str,
-            message_type: OptAttrSetupType[str] = None,
-            time: OptAttrSetupType[dtime_or_number_type] = None,
-            borehole_drift: OptAttrSetupType[number_type] = None,
-            vertical_depth: OptAttrSetupType[number_type] = None,
-            radial_drift: OptAttrSetupType[number_type] = None,
-            angular_drift: OptAttrSetupType[number_type] = None,
-            text: OptAttrSetupType[list[str]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        message_type: OptAttrSetupType[str] = None,
+        time: OptAttrSetupType[dtime_or_number_type] = None,
+        borehole_drift: OptAttrSetupType[number_type] = None,
+        vertical_depth: OptAttrSetupType[number_type] = None,
+        radial_drift: OptAttrSetupType[number_type] = None,
+        angular_drift: OptAttrSetupType[number_type] = None,
+        text: OptAttrSetupType[list[str]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.MessageItem:
         """Create a message and add it to DLIS.
 
@@ -1041,11 +1285,16 @@ class DLISFile:
             angular_drift       :   Angular drift.
             text                :   Text of the message.
             set_name            :   Name of the MessageSet this message should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured message.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.MessageSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         m = eflr_types.MessageItem(
             name=name,
@@ -1056,19 +1305,19 @@ class DLISFile:
             radial_drift=radial_drift,
             angular_drift=angular_drift,
             text=text,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.MessageSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return m
 
     def add_no_format(
-            self,
-            name: str,
-            consumer_name: OptAttrSetupType[str] = None,
-            description: OptAttrSetupType[str] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        consumer_name: OptAttrSetupType[str] = None,
+        description: OptAttrSetupType[str] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.NoFormatItem:
         """Create a no-format (a subtype of unformatted data logical record) item and add it to the DLIS.
 
@@ -1090,26 +1339,29 @@ class DLISFile:
             consumer_name       :   '[A] client-provided name for the data, for example an external file specification.'
             description         :   Description of the data item.
             set_name            :   Name of the NoFormatSet this item should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured no-format item.
         """
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.NoFormatSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
         nf = eflr_types.NoFormatItem(
             name=name,
             consumer_name=consumer_name,
             description=description,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.NoFormatSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return nf
 
     def add_no_format_frame_data(
-            self,
-            no_format_object: eflr_types.NoFormatItem,
-            data: str
+        self, no_format_object: eflr_types.NoFormatItem, data: str
     ) -> NoFormatFrameData:
         """Create a no-format frame data object.
 
@@ -1130,29 +1382,29 @@ class DLISFile:
         return d
 
     def add_origin(
-            self,
-            name: str,
-            file_set_number: OptAttrSetupType[int] = None,
-            file_set_name: OptAttrSetupType[str] = None,
-            file_id: OptAttrSetupType[str] = None,
-            file_number: OptAttrSetupType[int] = None,
-            file_type: OptAttrSetupType[str] = None,
-            product: OptAttrSetupType[str] = None,
-            version: OptAttrSetupType[str] = None,
-            programs: OptAttrSetupType[list[str]] = None,
-            creation_time: OptAttrSetupType[Union[datetime, str]] = None,
-            order_number: OptAttrSetupType[str] = None,
-            descent_number: OptAttrSetupType[int] = None,
-            run_number: OptAttrSetupType[int] = None,
-            well_id: OptAttrSetupType[int] = None,
-            well_name: OptAttrSetupType[str] = None,
-            field_name: OptAttrSetupType[str] = None,
-            producer_code: OptAttrSetupType[int] = None,
-            producer_name: OptAttrSetupType[str] = None,
-            company: OptAttrSetupType[str] = None,
-            name_space_name: OptAttrSetupType[str] = None,
-            name_space_version: OptAttrSetupType[int] = None,
-            set_name: Optional[str] = None
+        self,
+        name: str,
+        file_set_number: OptAttrSetupType[int] = None,
+        origin_reference: OptAttrSetupType[int] = None,
+        file_set_name: OptAttrSetupType[str] = None,
+        file_number: OptAttrSetupType[int] = None,
+        file_type: OptAttrSetupType[str] = None,
+        product: OptAttrSetupType[str] = None,
+        version: OptAttrSetupType[str] = None,
+        programs: OptAttrSetupType[list[str]] = None,
+        creation_time: OptAttrSetupType[Union[datetime, str]] = None,
+        order_number: OptAttrSetupType[str] = None,
+        descent_number: OptAttrSetupType[int] = None,
+        run_number: OptAttrSetupType[int] = None,
+        well_id: OptAttrSetupType[int] = None,
+        well_name: OptAttrSetupType[str] = None,
+        field_name: OptAttrSetupType[str] = None,
+        producer_code: OptAttrSetupType[int] = None,
+        producer_name: OptAttrSetupType[str] = None,
+        company: OptAttrSetupType[str] = None,
+        name_space_name: OptAttrSetupType[str] = None,
+        name_space_version: OptAttrSetupType[int] = None,
+        set_name: Optional[str] = None,
     ) -> eflr_types.OriginItem:
         """Create an origin.
 
@@ -1165,8 +1417,7 @@ class DLISFile:
 
         Args:
             name                :   Name of the object.
-            file_set_number     :   File set number. Used as 'origin reference' in all other objects added to the file.
-                                    If not specified, it is assigned randomly (in accordance with the RP66 specs).
+            file_set_number     :   If not specified, it is assigned randomly (in accordance with the RP66 specs).
                                     '[A] random number, called the File Set Number, that is used to distinguish
                                     the Logical Files of one File Set from the Logical Files of another File Set.
                                     This number should be such that there is a high probability that it uniquely
@@ -1174,16 +1425,13 @@ class DLISFile:
                                     of a given File Set. This Attribute must be present, even when the File-Set-Name
                                     Attribute is absent. In that case, it is considered to apply to the File Set
                                     consisting of the single current Logical File.'
+            origin_reference    :   This value is used as reference to the objects that are associated with this origin.
+                                    It is simpler to pass None. This way, a new, unique value, is assigned to this origin
             file_set_name       :   '[T]he name of a File Set, a group of Logical Files related according to
                                     Producer-defined criteria to which the Parent File belongs.
                                     The File Set is an arbitrary grouping of a set of Logical Files
                                     and has no DLIS semantic meaning. The File-Set-Name Attribute is not expected
                                     to be unique for all File Sets.'
-            file_id             :   '[A]n exact copy of the ID Attribute of the File-Header Object of the Parent File,
-                                    i.e., the Logical File for which this Origin Object is the Defining Origin.'
-                                    For defining origin (the first origin in the file) this will be set automatically,
-                                    so it does not have to be specified here. For other origins - origins defining other
-                                    DLIS files - the file_id should be specified manually.
             file_number         :   '[T]he File Number of the Parent File relative to the File Set specified by the
                                     File-Set-Name Attribute. File Numbers for a File Set are positive and increase
                                     in the order in which the Logical Files of the File Set are created.
@@ -1238,11 +1486,30 @@ class DLISFile:
             A configured OriginItem instance.
         """
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.OriginSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
+        origins = list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginSet))
+        origins_refs = [o.origin_reference for o in origins]
+        if origin_reference:
+            if origin_reference in origins_refs:
+                raise RuntimeError(
+                    f"There's already an origin with origin_reference {origin_reference} in this logical file."
+                )
+            next_available_origin_ref = origin_reference
+        else:
+            next_available_origin_ref = len(origins)
+        while next_available_origin_ref in origins_refs:
+            next_available_origin_ref += 1
+
         o = eflr_types.OriginItem(
             name=name,
+            origin_reference=origin_reference or next_available_origin_ref,
             file_set_number=file_set_number,
             file_set_name=file_set_name,
-            file_id=file_id,
+            file_id=self.file_header.header_id,
             file_number=file_number,
             file_type=file_type,
             product=product,
@@ -1260,31 +1527,42 @@ class DLISFile:
             company=company,
             name_space_name=name_space_name,
             name_space_version=name_space_version,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.OriginSet, set_name=set_name)
+            parent=parent,
         )
 
-        if len(list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginSet))) == 1:
-            ref = o.file_set_number.value
-            logger.info(f"Assigning origin reference {ref} to all EFLR items without origin reference defined")
-
+        if (
+            len(list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginSet)))
+            == 1
+        ):
+            logger.info(
+                f"Assigning origin reference {o.origin_reference} to all EFLR items without origin reference defined"
+            )
             for eflr_set_dict in self._eflr_sets.values():
                 for eflr_set in eflr_set_dict.values():
                     for eflr_item in eflr_set.get_all_eflr_items():
                         if eflr_item.origin_reference is None:
-                            eflr_item.origin_reference = ref
+                            eflr_item.origin_reference = o.origin_reference
+            for eflr_set_dict in self.physical_file._eflr_sets.values():
+                for eflr_set in eflr_set_dict.values():
+                    for eflr_item in eflr_set.get_all_eflr_items():
+                        if eflr_item.origin_reference is None:
+                            eflr_item.origin_reference = o.origin_reference
+
+            # Not enlisted in the sets. See Issue #
+            self.file_header_item.origin_reference = o.origin_reference
 
         return o
 
     def add_parameter(
-            self,
-            name: str,
-            long_name: OptAttrSetupType[Union[str, eflr_types.LongNameItem]] = None,
-            dimension: OptAttrSetupType[list[int]] = None,
-            axis: OptAttrSetupType[eflr_types.AxisItem] = None,
-            zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
-            values: OptAttrSetupType[NestedList[Union[str, int, float]]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        long_name: OptAttrSetupType[Union[str, eflr_types.LongNameItem]] = None,
+        dimension: OptAttrSetupType[list[int]] = None,
+        axis: OptAttrSetupType[eflr_types.AxisItem] = None,
+        zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
+        values: OptAttrSetupType[NestedList[Union[str, int, float]]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ParameterItem:
         """Create a parameter.
 
@@ -1310,11 +1588,16 @@ class DLISFile:
                                     to the kth zone. When the Parameter is Unzoned, there is a single Parameter value
                                     in the Values Attribute.'
             set_name            :   Name of the ParameterSet this parameter should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured ParameterItem instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ParameterSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         p = eflr_types.ParameterItem(
             name=name,
@@ -1323,28 +1606,30 @@ class DLISFile:
             axis=axis,
             zones=zones,
             values=values,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ParameterSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return p
 
     def add_path(
-            self,
-            name: str,
-            frame_type: OptAttrSetupType[eflr_types.FrameItem] = None,
-            well_reference_point: OptAttrSetupType[eflr_types.WellReferencePointItem] = None,
-            value: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            borehole_depth: OptAttrSetupType[number_type] = None,
-            vertical_depth: OptAttrSetupType[number_type] = None,
-            radial_drift: OptAttrSetupType[number_type] = None,
-            angular_drift: OptAttrSetupType[number_type] = None,
-            time: OptAttrSetupType[number_type] = None,
-            depth_offset: OptAttrSetupType[number_type] = None,
-            measure_point_offset: OptAttrSetupType[number_type] = None,
-            tool_zero_offset: OptAttrSetupType[number_type] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        frame_type: OptAttrSetupType[eflr_types.FrameItem] = None,
+        well_reference_point: OptAttrSetupType[
+            eflr_types.WellReferencePointItem
+        ] = None,
+        value: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
+        borehole_depth: OptAttrSetupType[number_type] = None,
+        vertical_depth: OptAttrSetupType[number_type] = None,
+        radial_drift: OptAttrSetupType[number_type] = None,
+        angular_drift: OptAttrSetupType[number_type] = None,
+        time: OptAttrSetupType[number_type] = None,
+        depth_offset: OptAttrSetupType[number_type] = None,
+        measure_point_offset: OptAttrSetupType[number_type] = None,
+        tool_zero_offset: OptAttrSetupType[number_type] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.PathItem:
         """Define a Path and add it to the DLIS.
 
@@ -1420,11 +1705,16 @@ class DLISFile:
                                         it is frequently zero.
                                         Specifically, Data Reference Point = Tool Zero Point + Tool-Zero-Offset.'
             set_name                :   Name of the PathSet this path should be added to.
-            origin_reference        :   file_set_number of the Origin this record belongs to.
+            origin_reference        :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured Path instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.PathSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         p = eflr_types.PathItem(
             name=name,
@@ -1439,28 +1729,32 @@ class DLISFile:
             depth_offset=depth_offset,
             measure_point_offset=measure_point_offset,
             tool_zero_offset=tool_zero_offset,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.PathSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return p
 
     def add_process(
-            self,
-            name: str,
-            description: OptAttrSetupType[str] = None,
-            trademark_name: OptAttrSetupType[str] = None,
-            version: OptAttrSetupType[str] = None,
-            properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
-            status: OptAttrSetupType[Union[str, enums.ProcessStatus]] = None,
-            input_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            output_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            input_computations: OptAttrSetupType[ListOrTuple[eflr_types.ComputationItem]] = None,
-            output_computations: OptAttrSetupType[ListOrTuple[eflr_types.ComputationItem]] = None,
-            parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
-            comments: OptAttrSetupType[list[str]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        description: OptAttrSetupType[str] = None,
+        trademark_name: OptAttrSetupType[str] = None,
+        version: OptAttrSetupType[str] = None,
+        properties: OptAttrSetupType[list[Union[str, enums.Property]]] = None,
+        status: OptAttrSetupType[Union[str, enums.ProcessStatus]] = None,
+        input_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
+        output_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
+        input_computations: OptAttrSetupType[
+            ListOrTuple[eflr_types.ComputationItem]
+        ] = None,
+        output_computations: OptAttrSetupType[
+            ListOrTuple[eflr_types.ComputationItem]
+        ] = None,
+        parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
+        comments: OptAttrSetupType[list[str]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ProcessItem:
         """Define a process item and add it to DLIS.
 
@@ -1487,11 +1781,16 @@ class DLISFile:
             comments            :   '[I]nformation specific to the particular execution of the process
                                     (generally provided by the user).'
             set_name            :   Name of the ProcessSet this process should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured ProcessItem instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ProcessSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         p = eflr_types.ProcessItem(
             name=name,
@@ -1506,20 +1805,20 @@ class DLISFile:
             output_computations=output_computations,
             parameters=parameters,
             comments=comments,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ProcessSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return p
 
     def add_splice(
-            self,
-            name: str,
-            output_channel: OptAttrSetupType[eflr_types.ChannelItem] = None,
-            input_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        output_channel: OptAttrSetupType[eflr_types.ChannelItem] = None,
+        input_channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
+        zones: OptAttrSetupType[ListOrTuple[eflr_types.ZoneItem]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.SpliceItem:
         """Create a splice object.
 
@@ -1542,35 +1841,40 @@ class DLISFile:
                                     must specify mutually-disjoint zones in the same domain, but the ordering
                                     of the zones is arbitrary.'
             set_name            :   Name of the SpliceSet this splice should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured splice.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.SpliceSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         sp = eflr_types.SpliceItem(
             name=name,
             output_channel=output_channel,
             input_channels=input_channels,
             zones=zones,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.SpliceSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return sp
 
     def add_tool(
-            self,
-            name: str,
-            description: OptAttrSetupType[str] = None,
-            trademark_name: OptAttrSetupType[str] = None,
-            generic_name: OptAttrSetupType[str] = None,
-            parts: OptAttrSetupType[ListOrTuple[eflr_types.EquipmentItem]] = None,
-            status: OptAttrSetupType[int] = None,
-            channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
-            parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        description: OptAttrSetupType[str] = None,
+        trademark_name: OptAttrSetupType[str] = None,
+        generic_name: OptAttrSetupType[str] = None,
+        parts: OptAttrSetupType[ListOrTuple[eflr_types.EquipmentItem]] = None,
+        status: OptAttrSetupType[int] = None,
+        channels: OptAttrSetupType[ListOrTuple[eflr_types.ChannelItem]] = None,
+        parameters: OptAttrSetupType[ListOrTuple[eflr_types.ParameterItem]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ToolItem:
         """Create a tool object.
 
@@ -1594,11 +1898,16 @@ class DLISFile:
             parameters          :   A list of ParameterItem objects `corresponding to Parameters that directly affect
                                     or reflect the operation of this Tool`.
             set_name            :   Name of the ToolSet this tool should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Returns:
             A configured tool.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ToolSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         t = eflr_types.ToolItem(
             name=name,
@@ -1609,28 +1918,28 @@ class DLISFile:
             status=status,
             channels=channels,
             parameters=parameters,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ToolSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return t
 
     def add_well_reference_point(
-            self,
-            name: str,
-            permanent_datum: OptAttrSetupType[str] = None,
-            vertical_zero: OptAttrSetupType[str] = None,
-            permanent_datum_elevation: OptAttrSetupType[number_type] = None,
-            above_permanent_datum: OptAttrSetupType[number_type] = None,
-            magnetic_declination: OptAttrSetupType[number_type] = None,
-            coordinate_1_name: OptAttrSetupType[str] = None,
-            coordinate_1_value: OptAttrSetupType[number_type] = None,
-            coordinate_2_name: OptAttrSetupType[str] = None,
-            coordinate_2_value: OptAttrSetupType[number_type] = None,
-            coordinate_3_name: OptAttrSetupType[str] = None,
-            coordinate_3_value: OptAttrSetupType[number_type] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        permanent_datum: OptAttrSetupType[str] = None,
+        vertical_zero: OptAttrSetupType[str] = None,
+        permanent_datum_elevation: OptAttrSetupType[number_type] = None,
+        above_permanent_datum: OptAttrSetupType[number_type] = None,
+        magnetic_declination: OptAttrSetupType[number_type] = None,
+        coordinate_1_name: OptAttrSetupType[str] = None,
+        coordinate_1_value: OptAttrSetupType[number_type] = None,
+        coordinate_2_name: OptAttrSetupType[str] = None,
+        coordinate_2_value: OptAttrSetupType[number_type] = None,
+        coordinate_3_name: OptAttrSetupType[str] = None,
+        coordinate_3_value: OptAttrSetupType[number_type] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.WellReferencePointItem:
         """Define a well reference point and add it to the DLIS.
 
@@ -1668,7 +1977,7 @@ class DLISFile:
                                             to locate the Well Reference Point.'
             coordinate_3_value          :   '[T]he numerical value of the [third] coordinate'.
             set_name                    :   Name of the WellReferencePointSet this item should be added to.
-            origin_reference            :   file_set_number of the Origin this record belongs to.
+            origin_reference            :   origin_reference of the Origin this record belongs to.
 
         Note:
             'Traditionally the coordinates of a well are described by latitude, longitude, and elevation.
@@ -1680,6 +1989,11 @@ class DLISFile:
         Returns:
             A configured WellReferencePointItem instance.
         """
+
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.WellReferencePointSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
 
         w = eflr_types.WellReferencePointItem(
             name=name,
@@ -1694,21 +2008,21 @@ class DLISFile:
             coordinate_2_value=coordinate_2_value,
             coordinate_3_name=coordinate_3_name,
             coordinate_3_value=coordinate_3_value,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.WellReferencePointSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=parent,
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return w
 
     def add_zone(
-            self,
-            name: str,
-            description: OptAttrSetupType[str] = None,
-            domain: OptAttrSetupType[Union[str, enums.ZoneDomain]] = None,
-            maximum: OptAttrSetupType[dtime_or_number_type] = None,
-            minimum: Optional[AttrSetupType[dtime_or_number_type]] = None,
-            set_name: Optional[str] = None,
-            origin_reference: Optional[int] = None
+        self,
+        name: str,
+        description: OptAttrSetupType[str] = None,
+        domain: OptAttrSetupType[Union[str, enums.ZoneDomain]] = None,
+        maximum: OptAttrSetupType[dtime_or_number_type] = None,
+        minimum: Optional[AttrSetupType[dtime_or_number_type]] = None,
+        set_name: Optional[str] = None,
+        origin_reference: Optional[int] = None,
     ) -> eflr_types.ZoneItem:
         """Create a zone (ZoneItem) and add it to the DLIS.
 
@@ -1732,7 +2046,7 @@ class DLISFile:
                                     When this Attribute is absent, the zone is considered to extend indefinitely
                                     in the direction corresponding to shallowest or earliest.'
             set_name            :   Name of the ZoneSet this zone should be added to.
-            origin_reference    :   file_set_number of the Origin this record belongs to.
+            origin_reference    :   origin_reference of the Origin this record belongs to.
 
         Note:
             Maximum and minimum should be instances of datetime.datetime if the domain is TIME. In other cases,
@@ -1742,14 +2056,19 @@ class DLISFile:
             A configured zone, added to the DLIS.
         """
 
+        parent = self.physical_file._eflr_sets.get_or_make_set(
+            eflr_types.ZoneSet, set_name=set_name
+        )
+        self._eflr_sets.try_add_set(parent)
+
         z = eflr_types.ZoneItem(
             name=name,
             description=description,
             domain=domain,
             maximum=maximum,
             minimum=minimum,
-            parent=self._eflr_sets.get_or_make_set(eflr_types.ZoneSet, set_name=set_name),
-            origin_reference=origin_reference or self.default_origin_reference
+            parent=self.physical_file._eflr_sets.get_or_make_set(eflr_types.ZoneSet, set_name=set_name),
+            origin_reference=origin_reference or self.default_origin_reference,
         )
 
         return z
@@ -1787,9 +2106,6 @@ class DLISFile:
         if not self.file_header:
             raise RuntimeError("No file header defined for the file")
 
-        if len(list(self._eflr_sets.get_all_items_for_set_type(eflr_types.FileHeaderSet))) > 1:
-            raise RuntimeError("Only one origin can be defined for the file")
-
         if not self.defining_origin:
             raise RuntimeError("No origin defined for the file")
 
@@ -1815,27 +2131,19 @@ class DLISFile:
 
         for ch, v in counts.items():
             if not v:
-                self.raise_or_warn(f"{ch} has not been added to any frame; this might cause issues "
-                                   f"with opening the produced DLIS file in some software")
+                raise_or_warn(f"{ch} has not been added to any frame; this might cause issues "
+                              f"with opening the produced DLIS file in some software")
             if v > 1:
-                self.raise_or_warn(f"{ch} has been added to {v} frames; according to RP66 v1, a channel "
-                                   f"can only be added to a single frame")
-
-    @staticmethod
-    def raise_or_warn(message: str) -> None:
-        """If high-compatibility mode is on, raise a RuntimeError with given message. Otherwise, put it in the logs."""
-
-        if global_config.high_compat_mode:
-            raise RuntimeError(message)
-        logger.warning(message)
+                raise_or_warn(f"{ch} has been added to {v} frames; according to RP66 v1, a channel "
+                              f"can only be added to a single frame")
 
     def _make_multi_frame_data(
-            self,
-            fr: eflr_types.FrameItem,
-            data: Optional[data_form_type] = None,
-            from_idx: int = 0,
-            to_idx: Optional[int] = None,
-            **kwargs: Any
+        self,
+        fr: eflr_types.FrameItem,
+        data: Optional[data_form_type] = None,
+        from_idx: int = 0,
+        to_idx: Optional[int] = None,
+        **kwargs: Any,
     ) -> MultiFrameData:
         """Create a MultiFrameData object, containing the frame and associated data, generating FrameData instances."""
 
@@ -1846,17 +2154,26 @@ class DLISFile:
 
         if isinstance(data, dict):
             self._data_dict = self._data_dict | data
-            data_object = DictDataWrapper(self._data_dict, mapping=fr.channel_name_mapping,
-                                          known_dtypes=fr.known_channel_dtypes_mapping,
-                                          from_idx=from_idx, to_idx=to_idx)
+            data_object = DictDataWrapper(
+                self._data_dict,
+                mapping=fr.channel_name_mapping,
+                known_dtypes=fr.known_channel_dtypes_mapping,
+                from_idx=from_idx,
+                to_idx=to_idx,
+            )
         else:
             if self._data_dict:
-                raise TypeError(f"Expected a dictionary of np.ndarrays; got {type(data)}: {data} "
-                                f"(Note: a dictionary is the only allowed type because some channels have been added"
-                                f"with associated data arrays")
+                raise TypeError(
+                    f"Expected a dictionary of np.ndarrays; got {type(data)}: {data} "
+                    f"(Note: a dictionary is the only allowed type because some channels have been added"
+                    f"with associated data arrays"
+                )
             data_object = SourceDataWrapper.make_wrapper(
-                data, mapping=fr.channel_name_mapping, known_dtypes=fr.known_channel_dtypes_mapping,
-                from_idx=from_idx, to_idx=to_idx
+                data,
+                mapping=fr.channel_name_mapping,
+                known_dtypes=fr.known_channel_dtypes_mapping,
+                from_idx=from_idx,
+                to_idx=to_idx,
             )
 
         self._check_data(data_object)
@@ -1872,86 +2189,5 @@ class DLISFile:
             raise RuntimeError("Data types not defined")
         for name in dt.names:
             if np.issubdtype(dt[name].base, np.signedinteger):
-                DLISFile.raise_or_warn(f"Data type of channel '{name}' is {dt[name].base}; some DLIS viewers cannot "
-                                       f"interpret signed integers correctly (overflow for negative values)")
-
-    def generate_logical_records(self, chunk_size: Optional[int], data: Optional[data_form_type] = None,
-                                 **kwargs: Any) -> SizedGenerator:
-        """Iterate over all logical records defined in the file.
-
-        Yields: EFLR and IFLR objects defined for the file.
-
-        Note: Storage Unit Label should be added to the file separately before adding other records.
-        """
-
-        frame_items: Generator[eflr_types.FrameItem, None, None] \
-            = self._eflr_sets.get_all_items_for_set_type(eflr_types.FrameSet)
-        multi_frame_data_objects: list[MultiFrameData] = [
-            self._make_multi_frame_data(fr, chunk_size=chunk_size, data=data, **kwargs) for fr in frame_items
-        ]
-
-        n = 0
-        for eflr_set_type in self._eflr_sets:
-            n += len(list(self._eflr_sets.get_all_items_for_set_type(eflr_set_type)))
-        for mfd in multi_frame_data_objects:
-            n += len(mfd)
-        n += len(self._no_format_frame_data)
-
-        def generator() -> Generator:
-            """Define a generator yielding logical records to be put in the file."""
-
-            if self.defining_origin is None:
-                raise RuntimeError("No Origin defined for the file")
-
-            yield self.file_header.parent
-            yield from self._eflr_sets[eflr_types.OriginSet].values()
-
-            for set_type, set_dict in self._eflr_sets.items():
-                if set_type not in (eflr_types.FileHeaderSet, eflr_types.OriginSet):
-                    yield from set_dict.values()
-
-            yield from self._no_format_frame_data
-
-            for multi_frame_data in multi_frame_data_objects:
-                yield from multi_frame_data
-
-        return SizedGenerator(generator(), size=n)
-
-    def write(
-            self,
-            dlis_file_name: file_name_type,
-            input_chunk_size: Optional[int] = None,
-            output_chunk_size: Optional[number_type] = 2**32,
-            data: Optional[data_form_type] = None,
-            from_idx: int = 0,
-            to_idx: Optional[int] = None
-    ) -> None:
-        """Create a DLIS file form the current specifications.
-
-        Args:
-            dlis_file_name          :   Name of the file to be created.
-            input_chunk_size        :   Size of the chunks (in rows) in which input data will be loaded to be processed.
-            output_chunk_size       :   Size of the buffers accumulating file bytes before file write action is called.
-            data                    :   Data for channels - if not specified when channels were added.
-            from_idx                :   Index from which the data should be loaded (or number of initial rows
-                                        to ignore).
-            to_idx                  :   Index up to which data should be loaded.
-        """
-
-        def timed_func() -> None:
-            """Perform the action of creating a DLIS file.
-
-            This function is used in a timeit call to time the file creation.
-            """
-
-            self.check_objects()
-
-            logical_records = self.generate_logical_records(
-                chunk_size=input_chunk_size, data=data, from_idx=from_idx, to_idx=to_idx)
-
-            writer = DLISWriter(dlis_file_name, visible_record_length=self.storage_unit_label.max_record_length)
-            writer.write_storage_unit_label(self.storage_unit_label)
-            writer.write_logical_records(logical_records, output_chunk_size=output_chunk_size)
-
-        exec_time = timeit(timed_func, number=1)
-        logger.info(f"DLIS file created in {timedelta(seconds=exec_time)} ({exec_time} seconds)")
+                raise_or_warn(f"Data type of channel '{name}' is {dt[name].base}; some DLIS viewers cannot "
+                              f"interpret signed integers correctly (overflow for negative values)")

--- a/src/dliswriter/logical_record/core/eflr/eflr_item.py
+++ b/src/dliswriter/logical_record/core/eflr/eflr_item.py
@@ -47,7 +47,7 @@ class EFLRItem:
             name                :   Name of the item. This will be the name it is stored with in the created DLIS file.
             parent              :   EFLRTable instance this item belongs to. If not provided,
                                         retrieved/made based on set_name.
-            origin_reference    :   'file_set_number' of the Origin; common for EFLRItems sharing the same Origin.
+            origin_reference    :   Common for EFLRItems sharing the same Origin.
             **kwargs            :   Values to be set in attributes of this item.
 
         Note:

--- a/src/dliswriter/logical_record/eflr_types/origin.py
+++ b/src/dliswriter/logical_record/eflr_types/origin.py
@@ -19,7 +19,13 @@ class OriginItem(EFLRItem):
 
     parent: "OriginSet"
 
-    def __init__(self, name: str, parent: "OriginSet", **kwargs: Any) -> None:
+    def __init__(
+        self,
+        name: str,
+        parent: "OriginSet",
+        origin_reference: int,
+        **kwargs: Any,
+    ) -> None:
         """Initialise OriginItem.
 
         Args:
@@ -50,7 +56,12 @@ class OriginItem(EFLRItem):
         self.name_space_name = IdentAttribute('name_space_name')
         self.name_space_version = NumericAttribute('name_space_version', representation_code=RepC.UVARI)
 
-        super().__init__(name, parent=parent, **kwargs)
+        super().__init__(
+            name,
+            parent=parent,
+            origin_reference=origin_reference,
+            **kwargs,
+        )
 
         if self.file_set_number.value is None:
             logger.info(f"File set number for {self} not specified")
@@ -70,13 +81,6 @@ class OriginItem(EFLRItem):
                 v = np.random.randint(1, max_val)
                 logger.info(f"Setting file set number of {self} to a randomly generated number: {v}")
                 self.file_set_number.value = v
-
-        if self._origin_reference is not None:
-            if self._origin_reference != self.file_set_number.value:
-                raise ValueError("Origin reference of an Origin should be the same as it's own file set number; "
-                                 f"got {self._origin_reference} and {self.file_set_number.value}")
-        else:
-            self._origin_reference = self.file_set_number.value
 
         if self.creation_time.value is None:
             logger.info("Creation time ('creation_time') not specified; setting it to the current date and time")

--- a/src/dliswriter/utils/internal/value_checkers.py
+++ b/src/dliswriter/utils/internal/value_checkers.py
@@ -34,10 +34,10 @@ def convert_numeric(value: str) -> Union[int, float, str]:
     parser = float if '.' in value else int
 
     try:
-        value = parser(value)
+        parsed_value = parser(value)
     except ValueError:
         raise ValueError(f"Value '{value}' could not be converted to a numeric type")
-    return value
+    return parsed_value
 
 
 def convert_maybe_numeric(val: Union[str, int, float]) -> Union[str, int, float]:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from pathlib import Path
-import h5py    # type: ignore  # untyped library
+import h5py  # type: ignore  # untyped library
 import os
 from typing import Generator
 
@@ -12,50 +12,50 @@ from tests.common import load_dlis
 from tests.dlis_files_for_testing import write_short_dlis
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def base_data_path() -> Path:
     """Path to the resources files."""
 
     return Path(__file__).resolve().parent
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def reference_data_path(base_data_path: Path) -> Path:
     """Path to the reference HDF5 data file."""
 
-    return base_data_path / 'resources/mock_data.hdf5'
+    return base_data_path / "resources/mock_data.hdf5"
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def reference_data(reference_data_path: Path) -> Generator:
     """The reference HDF5 data file, open in read mode."""
 
-    f = h5py.File(reference_data_path, 'r')
+    f = h5py.File(reference_data_path, "r")
     yield f
     f.close()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def short_reference_data_path(base_data_path: Path) -> Path:
     """Path to the HDF5 file with short version of the reference data."""
 
-    return base_data_path / 'resources/mock_data_short.hdf5'
+    return base_data_path / "resources/mock_data_short.hdf5"
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def short_reference_data(short_reference_data_path: Path) -> Generator:
     """The reference short HDF5 data file, open in read mode."""
 
-    f = h5py.File(short_reference_data_path, 'r')
+    f = h5py.File(short_reference_data_path, "r")
     yield f
     f.close()
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def short_dlis(short_reference_data_path: Path, base_data_path: Path) -> Generator:
     """A freshly written DLIS file - used in tests to check if all contents are there as expected."""
 
-    dlis_path = base_data_path / 'outputs/new_fake_dlis_shared.DLIS'
+    dlis_path = base_data_path / "outputs/new_fake_dlis_shared.DLIS"
     write_short_dlis(dlis_path, data=short_reference_data_path)
 
     with load_dlis(dlis_path) as f:
@@ -69,7 +69,7 @@ def short_dlis(short_reference_data_path: Path, base_data_path: Path) -> Generat
 def new_dlis_path(base_data_path: Path) -> Generator:
     """Path for a new DLIS file to be created. The file is removed afterwards."""
 
-    new_path = base_data_path/'outputs/new_fake_dlis.DLIS'
+    new_path = base_data_path / "outputs/new_fake_dlis.DLIS"
     os.makedirs(new_path.parent, exist_ok=True)
     yield new_path
 
@@ -105,13 +105,17 @@ def chan(channel_parent: eflr_types.ChannelSet) -> Generator:
 
 
 @pytest.fixture
-def channels(channel1: eflr_types.ChannelItem, channel2: eflr_types.ChannelItem, channel3: eflr_types.ChannelItem,
-             chan: eflr_types.ChannelItem) -> dict:
+def channels(
+    channel1: eflr_types.ChannelItem,
+    channel2: eflr_types.ChannelItem,
+    channel3: eflr_types.ChannelItem,
+    chan: eflr_types.ChannelItem,
+) -> dict:
     return {
-        'Channel 1': channel1,
-        'Channel 2': channel2,
-        'Channel 3': channel3,
-        'some_channel': chan
+        "Channel 1": channel1,
+        "Channel 2": channel2,
+        "Channel 3": channel3,
+        "some_channel": chan,
     }
 
 
@@ -119,18 +123,24 @@ def channels(channel1: eflr_types.ChannelItem, channel2: eflr_types.ChannelItem,
 def mock_data() -> NumpyDataWrapper:
     """Mock data (structured numpy array) for tests."""
 
-    dt = np.dtype([('time', float), ('amplitude', float, (10,)), ('radius', float, (12,))])
+    dt = np.dtype(
+        [("time", float), ("amplitude", float, (10,)), ("radius", float, (12,))]
+    )
     return NumpyDataWrapper(np.zeros(30, dtype=dt))
 
 
 @pytest.fixture
 def ccoef1() -> eflr_types.CalibrationCoefficientItem:
-    return eflr_types.CalibrationCoefficientItem("COEF-1", parent=eflr_types.CalibrationCoefficientSet())
+    return eflr_types.CalibrationCoefficientItem(
+        "COEF-1", parent=eflr_types.CalibrationCoefficientSet()
+    )
 
 
 @pytest.fixture
 def cmeasure1() -> eflr_types.CalibrationMeasurementItem:
-    return eflr_types.CalibrationMeasurementItem("CMEASURE-1", parent=eflr_types.CalibrationMeasurementSet())
+    return eflr_types.CalibrationMeasurementItem(
+        "CMEASURE-1", parent=eflr_types.CalibrationMeasurementSet()
+    )
 
 
 @pytest.fixture
@@ -179,7 +189,9 @@ def zone3(zone_parent: eflr_types.ZoneSet) -> eflr_types.ZoneItem:
 
 
 @pytest.fixture
-def zones(zone1: eflr_types.ZoneItem, zone2: eflr_types.ZoneItem, zone3: eflr_types.ZoneItem) -> dict:
+def zones(
+    zone1: eflr_types.ZoneItem, zone2: eflr_types.ZoneItem, zone3: eflr_types.ZoneItem
+) -> dict:
     return {"Zone-1": zone1, "Zone-2": zone2, "Zone-3": zone3}
 
 
@@ -199,16 +211,29 @@ def process2(process_parent: eflr_types.ProcessSet) -> eflr_types.ProcessItem:
 
 
 @pytest.fixture
-def channel_group(channel1: eflr_types.ChannelItem, channel2: eflr_types.ChannelItem,
-                  channel3: eflr_types.ChannelItem) -> eflr_types.GroupItem:
-    return eflr_types.GroupItem("Group of channels", object_type="CHANNEL",
-                                object_list=[channel1, channel2, channel3], parent=eflr_types.GroupSet())
+def channel_group(
+    channel1: eflr_types.ChannelItem,
+    channel2: eflr_types.ChannelItem,
+    channel3: eflr_types.ChannelItem,
+) -> eflr_types.GroupItem:
+    return eflr_types.GroupItem(
+        "Group of channels",
+        object_type="CHANNEL",
+        object_list=[channel1, channel2, channel3],
+        parent=eflr_types.GroupSet(),
+    )
 
 
 @pytest.fixture
-def process_group(process2: eflr_types.ProcessItem, process1: eflr_types.ProcessItem) -> eflr_types.GroupItem:
-    return eflr_types.GroupItem("Group of processes", object_type="PROCESS", object_list=[process1, process2],
-                                parent=eflr_types.GroupSet())
+def process_group(
+    process2: eflr_types.ProcessItem, process1: eflr_types.ProcessItem
+) -> eflr_types.GroupItem:
+    return eflr_types.GroupItem(
+        "Group of processes",
+        object_type="PROCESS",
+        object_list=[process1, process2],
+        parent=eflr_types.GroupSet(),
+    )
 
 
 @pytest.fixture
@@ -222,10 +247,17 @@ def computation2() -> eflr_types.ComputationItem:
 
 
 @pytest.fixture()
-def frame(channel1: eflr_types.ChannelItem, channel2: eflr_types.ChannelItem,
-          channel3: eflr_types.ChannelItem) -> eflr_types.FrameItem:
-    return eflr_types.FrameItem("MAIN FRAME", channels=(channel1, channel2, channel3),
-                                index_type='BOREHOLE-DEPTH', parent=eflr_types.FrameSet())
+def frame(
+    channel1: eflr_types.ChannelItem,
+    channel2: eflr_types.ChannelItem,
+    channel3: eflr_types.ChannelItem,
+) -> eflr_types.FrameItem:
+    return eflr_types.FrameItem(
+        "MAIN FRAME",
+        channels=(channel1, channel2, channel3),
+        index_type="BOREHOLE-DEPTH",
+        parent=eflr_types.FrameSet(),
+    )
 
 
 @pytest.fixture()
@@ -241,5 +273,5 @@ def well_reference_point() -> eflr_types.WellReferencePointItem:
         coordinate_1_value=40.395240,
         coordinate_2_name="Longitude",
         coordinate_2_value=27.792470,
-        parent=eflr_types.WellReferencePointSet()
+        parent=eflr_types.WellReferencePointSet(),
     )

--- a/src/tests/dlis_files_for_testing/common.py
+++ b/src/tests/dlis_files_for_testing/common.py
@@ -1,4 +1,4 @@
-from dliswriter import DLISFile, LogicalFile, StorageUnitLabel
+from dliswriter import DLISFile, StorageUnitLabel
 from dliswriter.logical_record.eflr_types import FileHeaderSet, FileHeaderItem
 
 

--- a/src/tests/dlis_files_for_testing/common.py
+++ b/src/tests/dlis_files_for_testing/common.py
@@ -1,13 +1,9 @@
-from dliswriter import DLISFile, StorageUnitLabel
+from dliswriter import DLISFile, LogicalFile, StorageUnitLabel
 from dliswriter.logical_record.eflr_types import FileHeaderSet, FileHeaderItem
 
 
 def make_file_header() -> FileHeaderItem:
-    return FileHeaderItem(
-        "DEFAULT FHLR",
-        sequence_number=1,
-        parent=FileHeaderSet()
-    )
+    return FileHeaderItem("DEFAULT FHLR", sequence_number=1, parent=FileHeaderSet())
 
 
 def make_sul() -> StorageUnitLabel:
@@ -15,6 +11,14 @@ def make_sul() -> StorageUnitLabel:
 
 
 def make_df() -> DLISFile:
-    df = DLISFile(storage_unit_label=make_sul(), file_header=make_file_header())
-    df.add_origin("DEFINING ORIGIN", creation_time="2050/03/02 15:30:00", file_set_number=1)
+    df = DLISFile(storage_unit_label=make_sul())
+
+    lf = df.add_logical_file(file_header=make_file_header())
+
+    lf.add_origin(
+        "DEFINING ORIGIN",
+        creation_time="2050/03/02 15:30:00",
+        file_set_number=1,
+        origin_reference=1,
+    )
     return df

--- a/src/tests/dlis_files_for_testing/depth_based_dlis.py
+++ b/src/tests/dlis_files_for_testing/depth_based_dlis.py
@@ -9,29 +9,31 @@ from dliswriter.utils.enums import Unit
 from tests.dlis_files_for_testing.common import make_df
 
 
-def _add_channels(df: DLISFile) -> tuple[eflr_types.ChannelItem, eflr_types.ChannelItem]:
-    ch_depth = df.add_channel(
+def _add_channels(
+    df: DLISFile, lf: int
+) -> tuple[eflr_types.ChannelItem, eflr_types.ChannelItem]:
+    ch_depth = df.logical_files[lf].add_channel(
         name="depth",
         dataset_name="/contents/depth",
         units=Unit.METER,
-        cast_dtype=np.float64
+        cast_dtype=np.float64,
     )
 
-    ch_rpm = df.add_channel(
+    ch_rpm = df.logical_files[lf].add_channel(
         name="surface rpm",
         dataset_name="contents/rpm",
         cast_dtype=np.float64,
-        dimension=[1]
+        dimension=[1],
     )
 
     return ch_depth, ch_rpm
 
 
-def _add_frame(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...]) -> eflr_types.FrameItem:
-    fr = df.add_frame(
-        name="MAIN",
-        index_type="DEPTH",
-        channels=channels
+def _add_frame(
+    df: DLISFile, lf: int, channels: tuple[eflr_types.ChannelItem, ...]
+) -> eflr_types.FrameItem:
+    fr = df.logical_files[lf].add_frame(
+        name="MAIN", index_type="DEPTH", channels=channels
     )
 
     fr.spacing.units = "m"
@@ -42,13 +44,15 @@ def _add_frame(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...]) -> ef
 def create_dlis_file_object() -> DLISFile:
     df = make_df()
 
-    channels = _add_channels(df)
-    _add_frame(df, channels)
+    logical_file_index = 0
+    channels = _add_channels(df, logical_file_index)
+    _add_frame(df, logical_file_index, channels)
 
     return df
 
 
-def write_depth_based_dlis(fname: Union[str, os.PathLike[str]], data: Union[dict, os.PathLike[str], np.ndarray])\
-        -> None:
+def write_depth_based_dlis(
+    fname: Union[str, os.PathLike[str]], data: Union[dict, os.PathLike[str], np.ndarray]
+) -> None:
     df = create_dlis_file_object()
     df.write(fname, data=data)

--- a/src/tests/dlis_files_for_testing/dlis_from_dict.py
+++ b/src/tests/dlis_files_for_testing/dlis_from_dict.py
@@ -8,28 +8,35 @@ from dliswriter.utils.enums import FrameIndexType
 from tests.dlis_files_for_testing.common import make_df
 
 
-def _add_channels(df: DLISFile, data_dict: dict, channel_kwargs: Optional[dict] = None) \
-        -> tuple[eflr_types.ChannelItem, ...]:
+def _add_channels(
+    df: DLISFile, lf: int, data_dict: dict, channel_kwargs: Optional[dict] = None
+) -> tuple[eflr_types.ChannelItem, ...]:
 
     channel_kwargs = channel_kwargs or {}
 
     channels = []
     for key, value in data_dict.items():
-        ch = df.add_channel(
-            name=key,
-            data=value,
-            **channel_kwargs.get(key, {})
+        ch = df.logical_files[lf].add_channel(
+            name=key, data=value, **channel_kwargs.get(key, {})
         )
         channels.append(ch)
 
     return tuple(channels)
 
 
-def write_dlis_from_dict(fname: Union[str, os.PathLike[str]], data_dict: dict,
-                         channel_kwargs: Optional[dict] = None) -> None:
+def write_dlis_from_dict(
+    fname: Union[str, os.PathLike[str]],
+    data_dict: dict,
+    channel_kwargs: Optional[dict] = None,
+) -> None:
     df = make_df()
 
-    channels = _add_channels(df, data_dict=data_dict, channel_kwargs=channel_kwargs)
-    df.add_frame("MAIN", index_type=FrameIndexType.VERTICAL_DEPTH, channels=channels)
+    logical_file_index = 0
+    channels = _add_channels(
+        df, logical_file_index, data_dict=data_dict, channel_kwargs=channel_kwargs
+    )
+    df.logical_files[logical_file_index].add_frame(
+        "MAIN", index_type=FrameIndexType.VERTICAL_DEPTH, channels=channels
+    )
 
     df.write(fname)

--- a/src/tests/dlis_files_for_testing/double_frame_dlis.py
+++ b/src/tests/dlis_files_for_testing/double_frame_dlis.py
@@ -1,35 +1,40 @@
 import os
 from typing import Union
 
-from dliswriter.file import DLISFile
+from dliswriter import (
+    DLISFile,
+    LogicalFile,
+)
 from dliswriter.utils.enums import FrameIndexType
 
 from tests.dlis_files_for_testing.common import make_df
 
 
-def _define_frame_from_data(df: DLISFile, name: str, data: dict) -> None:
-    ax = df.add_axis("AXIS")
+def _define_frame_from_data(lf: LogicalFile, name: str, data: dict) -> None:
+    ax = lf.add_axis("AXIS")
 
     channels = []
     for i, (ch_name, ch_data) in enumerate(data.items()):
-        ch = df.add_channel(ch_name, data=ch_data)
+        ch = lf.add_channel(ch_name, data=ch_data)
         if not i:
             ch.axis.value = ax
         channels.append(ch)
 
-    df.add_frame(name, channels=channels, index_type=FrameIndexType.BOREHOLE_DEPTH)
+    lf.add_frame(name, channels=channels, index_type=FrameIndexType.BOREHOLE_DEPTH)
 
 
 def create_dlis_file_object(*data_dicts: dict) -> DLISFile:
     df = make_df()
 
     for i, d in enumerate(data_dicts):
-        _define_frame_from_data(df, f'FRAME{i+1}', d)
+        _define_frame_from_data(df.logical_files[0], f"FRAME{i+1}", d)
 
     return df
 
 
-def write_double_frame_dlis(fname: Union[str, os.PathLike[str]], *frame_data: dict) -> DLISFile:
+def write_double_frame_dlis(
+    fname: Union[str, os.PathLike[str]], *frame_data: dict
+) -> DLISFile:
     df = create_dlis_file_object(*frame_data)
     df.write(fname)
 

--- a/src/tests/dlis_files_for_testing/short_dlis.py
+++ b/src/tests/dlis_files_for_testing/short_dlis.py
@@ -3,52 +3,70 @@ from typing import Union
 import numpy as np
 from datetime import datetime
 
-from dliswriter.file import DLISFile
+from dliswriter import (
+    DLISFile,
+    LogicalFile,
+)
 from dliswriter.logical_record import eflr_types
-from dliswriter.utils.enums import (Unit, Property, ZoneDomain, EquipmentType, EquipmentLocation,
-                                    CalibrationMeasurementPhase, ProcessStatus)
+from dliswriter.utils.enums import (
+    Unit,
+    Property,
+    ZoneDomain,
+    EquipmentType,
+    EquipmentLocation,
+    CalibrationMeasurementPhase,
+    ProcessStatus,
+)
 
 from tests.dlis_files_for_testing.common import make_file_header, make_sul
 
 
-def _add_origin(df: DLISFile) -> eflr_types.OriginItem:
-    origin = df.add_origin(
+def _add_origin(lf: LogicalFile) -> eflr_types.OriginItem:
+    origin = lf.add_origin(
         "DEFAULT ORIGIN",
         creation_time="2050/03/02 15:30:00",
         file_set_name="Test file set name",
         file_set_number=42,
+        origin_reference=42,
         file_number=8,
         run_number=13,
         well_id=5,
         well_name="Test well name",
         field_name="Test field name",
-        company="Test company"
+        company="Test company",
     )
 
     return origin
 
 
-def _add_frame(df: DLISFile, *channels: eflr_types.ChannelItem) -> eflr_types.FrameItem:
-    fr = df.add_frame(
+def _add_frame(
+    lf: LogicalFile, *channels: eflr_types.ChannelItem
+) -> eflr_types.FrameItem:
+    fr = lf.add_frame(
         "MAIN FRAME",
         channels=channels,
         index_type="TIME",
         spacing=0.5,
         encrypted=1,
-        description="Frame description"
+        description="Frame description",
     )
 
     fr.spacing.units = Unit.SECOND
     return fr
 
 
-def _add_channels(df: DLISFile, ax1: eflr_types.AxisItem,
-                  ln: eflr_types.LongNameItem) -> tuple[eflr_types.ChannelItem, ...]:
-    ch = df.add_channel(
+def _add_channels(
+    lf: LogicalFile, ax1: eflr_types.AxisItem, ln: eflr_types.LongNameItem
+) -> tuple[eflr_types.ChannelItem, ...]:
+    ch = lf.add_channel(
         name="Some Channel",
         dataset_name="image1",
         long_name="Some not so very long channel name",
-        properties=[Property.AVERAGED, Property.LOCALLY_DEFINED, Property.SPEED_CORRECTED],
+        properties=[
+            Property.AVERAGED,
+            Property.LOCALLY_DEFINED,
+            Property.SPEED_CORRECTED,
+        ],
         cast_dtype=np.float32,
         units=Unit.ACRE,
         dimension=12,
@@ -58,91 +76,97 @@ def _add_channels(df: DLISFile, ax1: eflr_types.AxisItem,
         maximum_value=127.6,
     )
 
-    ch1 = df.add_channel(name="Channel 1", dimension=[10, 10], units=Unit.INCH)
-    ch2 = df.add_channel("Channel 2", long_name=ln)
-    ch3 = df.add_channel("Channel 13", dataset_name='amplitude', element_limit=128)
-    ch_time = df.add_channel("posix time", dataset_name="contents/time", units=Unit.SECOND)
-    ch_rpm = df.add_channel("surface rpm", dataset_name="contents/rpm", long_name=ln)
-    ch_amplitude = df.add_channel("amplitude", dataset_name="contents/image0", dimension=128)
-    ch_radius = df.add_channel("radius", dataset_name="contents/image1", dimension=128, units="in")
-    ch_radius_pooh = df.add_channel("radius_pooh", dataset_name="contents/image2", units=Unit.METER)
-    ch_x = df.add_channel("channel_x", long_name="Channel not added to the frame", dataset_name="image2", units="s")
+    ch1 = lf.add_channel(name="Channel 1", dimension=[10, 10], units=Unit.INCH)
+    ch2 = lf.add_channel("Channel 2", long_name=ln)
+    ch3 = lf.add_channel("Channel 13", dataset_name="amplitude", element_limit=128)
+    ch_time = lf.add_channel(
+        "posix time", dataset_name="contents/time", units=Unit.SECOND
+    )
+    ch_rpm = lf.add_channel("surface rpm", dataset_name="contents/rpm", long_name=ln)
+    ch_amplitude = lf.add_channel(
+        "amplitude", dataset_name="contents/image0", dimension=128
+    )
+    ch_radius = lf.add_channel(
+        "radius", dataset_name="contents/image1", dimension=128, units="in"
+    )
+    ch_radius_pooh = lf.add_channel(
+        "radius_pooh", dataset_name="contents/image2", units=Unit.METER
+    )
+    ch_x = lf.add_channel(
+        "channel_x",
+        long_name="Channel not added to the frame",
+        dataset_name="image2",
+        units="s",
+    )
 
-    return ch, ch1, ch2, ch3, ch_time, ch_rpm, ch_amplitude, ch_radius, ch_radius_pooh, ch_x
+    return (
+        ch,
+        ch1,
+        ch2,
+        ch3,
+        ch_time,
+        ch_rpm,
+        ch_amplitude,
+        ch_radius,
+        ch_radius_pooh,
+        ch_x,
+    )
 
 
-def _add_axes(df: DLISFile) -> tuple[eflr_types.AxisItem, ...]:
-    ax1 = df.add_axis(
-        name="Axis-1",
-        axis_id="First axis",
-        coordinates=list(range(12)),
-        spacing=1
+def _add_axes(lf: LogicalFile) -> tuple[eflr_types.AxisItem, ...]:
+    ax1 = lf.add_axis(
+        name="Axis-1", axis_id="First axis", coordinates=list(range(12)), spacing=1
     )
     ax1.spacing.units = Unit.METER
 
-    ax2 = df.add_axis(
-        "Axis-X",
-        axis_id="Axis not added to computation",
-        coordinates=[8],
-        spacing=2
+    ax2 = lf.add_axis(
+        "Axis-X", axis_id="Axis not added to computation", coordinates=[8], spacing=2
     )
     ax2.spacing.units = "m"
 
-    ax3 = df.add_axis(
-        name="Axis-3",
-        axis_id="Whatever axis",
-        coordinates=[1, 5.5, 8]
-    )
+    ax3 = lf.add_axis(name="Axis-3", axis_id="Whatever axis", coordinates=[1, 5.5, 8])
 
-    ax4 = df.add_axis(
-        name="Axis-4",
-        axis_id="Whatever axis nr 2",
-        coordinates=[-1, 0]
-    )
+    ax4 = lf.add_axis(name="Axis-4", axis_id="Whatever axis nr 2", coordinates=[-1, 0])
 
     return ax1, ax2, ax3, ax4
 
 
-def _add_zones(df: DLISFile) -> tuple[eflr_types.ZoneItem, ...]:
-    z1 = df.add_zone(
+def _add_zones(lf: LogicalFile) -> tuple[eflr_types.ZoneItem, ...]:
+    z1 = lf.add_zone(
         name="Zone-1",
         description="BOREHOLE-DEPTH-ZONE",
         domain="BOREHOLE-DEPTH",
         maximum=1300,
-        minimum=100
+        minimum=100,
     )
     z1.maximum.units = "m"
     z1.minimum.units = "m"
 
-    z2 = df.add_zone(
+    z2 = lf.add_zone(
         "Zone-2",
         description="VERTICAL-DEPTH-ZONE",
         domain=ZoneDomain.VERTICAL_DEPTH,
         maximum=2300.45,
-        minimum=200.0
+        minimum=200.0,
     )
     z2.maximum.units = Unit.METER
     z2.minimum.units = "m"
 
-    z3 = df.add_zone(
+    z3 = lf.add_zone(
         "Zone-3",
         description="ZONE-TIME",
         domain=ZoneDomain.TIME,
         maximum="2050/07/13 11:30:00",
-        minimum="2050/07/12 9:00:00"
+        minimum="2050/07/12 9:00:00",
     )
 
-    z4 = df.add_zone(
-        "Zone-4",
-        description="ZONE-TIME-2",
-        domain="TIME",
-        maximum=90,
-        minimum=10
+    z4 = lf.add_zone(
+        "Zone-4", description="ZONE-TIME-2", domain="TIME", maximum=90, minimum=10
     )
     z4.maximum.units = "min"
     z4.minimum.units = Unit.MINUTE
 
-    zx = df.add_zone(
+    zx = lf.add_zone(
         name="Zone-X",
         description="Zone not added to any parameter",
         domain="TIME",
@@ -155,16 +179,17 @@ def _add_zones(df: DLISFile) -> tuple[eflr_types.ZoneItem, ...]:
     return z1, z2, z3, z4, zx
 
 
-def _add_parameters(df: DLISFile, zones: tuple[eflr_types.ZoneItem, ...],
-                    ln: eflr_types.LongNameItem) -> tuple[eflr_types.ParameterItem, ...]:
-    p1 = df.add_parameter(
+def _add_parameters(
+    lf: LogicalFile, zones: tuple[eflr_types.ZoneItem, ...], ln: eflr_types.LongNameItem
+) -> tuple[eflr_types.ParameterItem, ...]:
+    p1 = lf.add_parameter(
         name="Param-1",
         long_name="LATLONG-GPS",
         zones=[zones[0], zones[2]],
-        values=["40deg 23' 42.8676'' N", "40deg 23' 42.8676'' N"]
+        values=["40deg 23' 42.8676'' N", "40deg 23' 42.8676'' N"],
     )
 
-    p2 = df.add_parameter(
+    p2 = lf.add_parameter(
         name="Param-2",
         long_name="LATLONG",
         zones=[zones[1], zones[3]],
@@ -172,18 +197,14 @@ def _add_parameters(df: DLISFile, zones: tuple[eflr_types.ZoneItem, ...],
         values=[[40.395241, 27.792471, 21.23131213], [21, 23, 24]],
     )
 
-    p3 = df.add_parameter(
-        name="Param-3",
-        long_name=ln,
-        values=[12.5]
-    )
+    p3 = lf.add_parameter(name="Param-3", long_name=ln, values=[12.5])
     p3.values.units = Unit.METER
 
     return p1, p2, p3
 
 
-def _add_equipment(df: DLISFile) -> tuple[eflr_types.EquipmentItem, ...]:
-    eq1 = df.add_equipment(
+def _add_equipment(lf: LogicalFile) -> tuple[eflr_types.EquipmentItem, ...]:
+    eq1 = lf.add_equipment(
         name="EQ1",
         trademark_name="EQ-TRADEMARKNAME",
         status=1,
@@ -216,29 +237,32 @@ def _add_equipment(df: DLISFile) -> tuple[eflr_types.EquipmentItem, ...]:
     eq1.radial_drift.units = "m"
     eq1.angular_drift.units = Unit.METER
 
-    eq2 = df.add_equipment(
+    eq2 = lf.add_equipment(
         name="EQ2",
         trademark_name="EQ-TRADEMARKNAME",
         status=0,
         eq_type=EquipmentType.TOOL,
-        serial_number="5559101-21391"
+        serial_number="5559101-21391",
     )
 
-    eq3 = df.add_equipment(
+    eq3 = lf.add_equipment(
         name="EqX",
         trademark_name="EQ-TRADEMARKNAME",
         status=1,
         eq_type="Tool",
-        serial_number="12311"
+        serial_number="12311",
     )
 
     return eq1, eq2, eq3
 
 
-def _add_tools(df: DLISFile, equipment: tuple[eflr_types.EquipmentItem, ...],
-               parameters: tuple[eflr_types.ParameterItem, ...], channels: tuple[eflr_types.ChannelItem, ...]) \
-        -> tuple[eflr_types.ToolItem, ...]:
-    t1 = df.add_tool(
+def _add_tools(
+    lf: LogicalFile,
+    equipment: tuple[eflr_types.EquipmentItem, ...],
+    parameters: tuple[eflr_types.ParameterItem, ...],
+    channels: tuple[eflr_types.ChannelItem, ...],
+) -> tuple[eflr_types.ToolItem, ...]:
+    t1 = lf.add_tool(
         name="TOOL-1",
         description="SOME TOOL",
         trademark_name="SMTL",
@@ -246,10 +270,10 @@ def _add_tools(df: DLISFile, equipment: tuple[eflr_types.EquipmentItem, ...],
         parts=[equipment[0], equipment[1]],
         status=1,
         channels=[channels[4], channels[6]],
-        parameters=[parameters[0], parameters[2]]
+        parameters=[parameters[0], parameters[2]],
     )
 
-    t2 = df.add_tool(
+    t2 = lf.add_tool(
         name="Tool-X",
         description="desc",
         trademark_name="SMTL",
@@ -257,16 +281,19 @@ def _add_tools(df: DLISFile, equipment: tuple[eflr_types.EquipmentItem, ...],
         parts=[equipment[1]],
         status=0,
         channels=[channels[8]],
-        parameters=[parameters[1]]
+        parameters=[parameters[1]],
     )
 
     return t1, t2
 
 
-def _add_processes(df: DLISFile, parameters: tuple[eflr_types.ParameterItem, ...],
-                   channels: tuple[eflr_types.ChannelItem, ...], computations: tuple[eflr_types.ComputationItem, ...]) \
-        -> tuple[eflr_types.ProcessItem, ...]:
-    p1 = df.add_process(
+def _add_processes(
+    lf: LogicalFile,
+    parameters: tuple[eflr_types.ParameterItem, ...],
+    channels: tuple[eflr_types.ChannelItem, ...],
+    computations: tuple[eflr_types.ComputationItem, ...],
+) -> tuple[eflr_types.ProcessItem, ...]:
+    p1 = lf.add_process(
         name="Process 1",
         description="MERGED",
         trademark_name="PROCESS 1",
@@ -278,10 +305,10 @@ def _add_processes(df: DLISFile, parameters: tuple[eflr_types.ParameterItem, ...
         input_computations=[computations[0]],
         output_computations=[computations[1]],
         parameters=parameters,
-        comments=["SOME COMMENT HERE"]
+        comments=["SOME COMMENT HERE"],
     )
 
-    p2 = df.add_process(
+    p2 = lf.add_process(
         name="Prc2",
         description="MERGED2",
         trademark_name="PROCESS 2",
@@ -292,16 +319,20 @@ def _add_processes(df: DLISFile, parameters: tuple[eflr_types.ParameterItem, ...
         output_channels=[channels[2]],
         input_computations=[computations[1], computations[0]],
         parameters=[parameters[0]],
-        comments=["Other comment"]
+        comments=["Other comment"],
     )
 
     return p1, p2
 
 
-def _add_computation(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...], zones: tuple[eflr_types.ZoneItem, ...],
-                     tools: tuple[eflr_types.ToolItem, ...], ln: eflr_types.LongNameItem
-                     ) -> tuple[eflr_types.ComputationItem, ...]:
-    c1 = df.add_computation(
+def _add_computation(
+    lf: LogicalFile,
+    axes: tuple[eflr_types.AxisItem, ...],
+    zones: tuple[eflr_types.ZoneItem, ...],
+    tools: tuple[eflr_types.ToolItem, ...],
+    ln: eflr_types.LongNameItem,
+) -> tuple[eflr_types.ComputationItem, ...]:
+    c1 = lf.add_computation(
         name="COMPT-1",
         long_name="COMPT1",
         properties=[Property.LOCALLY_DEFINED, "AVERAGED"],
@@ -309,20 +340,20 @@ def _add_computation(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...], zones:
         axis=[axes[2]],
         zones=zones[:2],
         values=[[100, 200, 300], [1, 2, 3]],
-        source=tools[0]
+        source=tools[0],
     )
 
-    c2 = df.add_computation(
+    c2 = lf.add_computation(
         name="COMPT2",
         long_name=ln,
         properties=["UNDER-SAMPLED", Property.AVERAGED],
         dimension=[2],
         axis=[axes[3]],
         zones=[zones[0], zones[2]],
-        values=[[1.5, 2.5], [4.5, 3.2]]
+        values=[[1.5, 2.5], [4.5, 3.2]],
     )
 
-    cx = df.add_computation(
+    cx = lf.add_computation(
         name="COMPT-X",
         long_name="Computation not added to process",
         properties=["OVER-SAMPLED"],
@@ -334,26 +365,32 @@ def _add_computation(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...], zones:
     return c1, c2, cx
 
 
-def _add_splices(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...], zones: tuple[eflr_types.ZoneItem, ...]) \
-        -> tuple[eflr_types.SpliceItem]:
-    s = df.add_splice(
+def _add_splices(
+    lf: LogicalFile,
+    channels: tuple[eflr_types.ChannelItem, ...],
+    zones: tuple[eflr_types.ZoneItem, ...],
+) -> tuple[eflr_types.SpliceItem]:
+    s = lf.add_splice(
         name="splc1",
         output_channel=channels[6],
         input_channels=[channels[1], channels[2]],
-        zones=[zones[0], zones[1]]
+        zones=[zones[0], zones[1]],
     )
 
-    return s,
+    return (s,)
 
 
-def _add_calibrations(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...],
-                      channels: tuple[eflr_types.ChannelItem, ...],
-                      parameters: tuple[eflr_types.ParameterItem, ...]) \
-        -> tuple[
-            eflr_types.CalibrationMeasurementItem,
-            eflr_types.CalibrationCoefficientItem,
-            eflr_types.CalibrationItem]:
-    cm = df.add_calibration_measurement(
+def _add_calibrations(
+    lf: LogicalFile,
+    axes: tuple[eflr_types.AxisItem, ...],
+    channels: tuple[eflr_types.ChannelItem, ...],
+    parameters: tuple[eflr_types.ParameterItem, ...],
+) -> tuple[
+    eflr_types.CalibrationMeasurementItem,
+    eflr_types.CalibrationCoefficientItem,
+    eflr_types.CalibrationItem,
+]:
+    cm = lf.add_calibration_measurement(
         name="CMEASURE-1",
         phase=CalibrationMeasurementPhase.BEFORE,
         axis=axes[3],
@@ -372,7 +409,7 @@ def _add_calibrations(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...],
     )
     cm.duration.units = "s"
 
-    cc = df.add_calibration_coefficient(
+    cc = lf.add_calibration_coefficient(
         name="COEF-1",
         label="Gain",
         coefficients=[100.2, 201.3],
@@ -381,21 +418,23 @@ def _add_calibrations(df: DLISFile, axes: tuple[eflr_types.AxisItem, ...],
         minus_tolerances=[87.23, 214],
     )
 
-    c = df.add_calibration(
+    c = lf.add_calibration(
         name="CALIB-MAIN",
         calibrated_channels=[channels[1], channels[2]],
         uncalibrated_channels=[channels[6], channels[7], channels[8]],
         coefficients=[cc],
         measurements=[cm],
         parameters=parameters,
-        method="Two Point Linear"
+        method="Two Point Linear",
     )
 
     return cm, cc, c
 
 
-def _add_well_reference_points(df: DLISFile) -> tuple[eflr_types.WellReferencePointItem, ...]:
-    w1 = df.add_well_reference_point(
+def _add_well_reference_points(
+    lf: LogicalFile,
+) -> tuple[eflr_types.WellReferencePointItem, ...]:
+    w1 = lf.add_well_reference_point(
         name="AQLN WELL-REF",
         permanent_datum="AQLN permanent_datum",
         vertical_zero="AQLN vertical_zero",
@@ -405,10 +444,10 @@ def _add_well_reference_points(df: DLISFile) -> tuple[eflr_types.WellReferencePo
         coordinate_1_name="Latitude",
         coordinate_1_value=40.395240,
         coordinate_2_name="Longitude",
-        coordinate_2_value=27.792470
+        coordinate_2_value=27.792470,
     )
 
-    w2 = df.add_well_reference_point(
+    w2 = lf.add_well_reference_point(
         name="WRP-X",
         permanent_datum="pd1",
         vertical_zero="vz20",
@@ -420,16 +459,20 @@ def _add_well_reference_points(df: DLISFile) -> tuple[eflr_types.WellReferencePo
         coordinate_2_name="Y",
         coordinate_2_value=-0.3,
         coordinate_3_name="Z",
-        coordinate_3_value=1
+        coordinate_3_value=1,
     )
 
     return w1, w2
 
 
-def _add_paths(df: DLISFile, frame: eflr_types.FrameItem, wrp: eflr_types.WellReferencePointItem,
-               channels: tuple[eflr_types.ChannelItem, ...]) -> tuple[eflr_types.PathItem, ...]:
-    path1 = df.add_path(
-        'PATH-1',
+def _add_paths(
+    lf: LogicalFile,
+    frame: eflr_types.FrameItem,
+    wrp: eflr_types.WellReferencePointItem,
+    channels: tuple[eflr_types.ChannelItem, ...],
+) -> tuple[eflr_types.PathItem, ...]:
+    path1 = lf.add_path(
+        "PATH-1",
         frame_type=frame,
         well_reference_point=wrp,
         value=(channels[0], channels[1], channels[2]),
@@ -437,16 +480,18 @@ def _add_paths(df: DLISFile, frame: eflr_types.FrameItem, wrp: eflr_types.WellRe
         vertical_depth=211.1,
         radial_drift=12,
         angular_drift=1.11,
-        time=13
+        time=13,
     )
 
-    path2 = df.add_path('PATH-2', value=(channels[4],), tool_zero_offset=1231.1, time=11.1)
+    path2 = lf.add_path(
+        "PATH-2", value=(channels[4],), tool_zero_offset=1231.1, time=11.1
+    )
 
     return path1, path2
 
 
-def _add_messages(df: DLISFile) -> tuple[eflr_types.MessageItem]:
-    m = df.add_message(
+def _add_messages(lf: LogicalFile) -> tuple[eflr_types.MessageItem]:
+    m = lf.add_message(
         name="MESSAGE-1",
         message_type="Command",
         time=datetime(year=2050, month=3, day=4, hour=11, minute=23, second=11),
@@ -454,44 +499,38 @@ def _add_messages(df: DLISFile) -> tuple[eflr_types.MessageItem]:
         vertical_depth=234.45,
         radial_drift=345.56,
         angular_drift=456.67,
-        text=["Test message 11111"]
+        text=["Test message 11111"],
     )
 
-    return m,
+    return (m,)
 
 
-def _add_comments(df: DLISFile) -> tuple[eflr_types.CommentItem, ...]:
-    c1 = df.add_comment(
-        name="COMMENT-1",
-        text=["SOME COMMENT HERE"]
-    )
+def _add_comments(lf: LogicalFile) -> tuple[eflr_types.CommentItem, ...]:
+    c1 = lf.add_comment(name="COMMENT-1", text=["SOME COMMENT HERE"])
 
-    c2 = df.add_comment(
-        name="cmt2",
-        text=["some other comment here", "and another comment"]
+    c2 = lf.add_comment(
+        name="cmt2", text=["some other comment here", "and another comment"]
     )
 
     return c1, c2
 
 
-def _add_no_formats(df: DLISFile) -> tuple[eflr_types.NoFormatItem, ...]:
-    nf1 = df.add_no_format(
+def _add_no_formats(lf: LogicalFile) -> tuple[eflr_types.NoFormatItem, ...]:
+    nf1 = lf.add_no_format(
         name="no_format_1",
         consumer_name="SOME TEXT NOT FORMATTED",
-        description="TESTING-NO-FORMAT"
+        description="TESTING-NO-FORMAT",
     )
 
-    nf2 = df.add_no_format(
-        name="no_fmt2",
-        consumer_name="xyz",
-        description="TESTING NO FORMAT 2"
+    nf2 = lf.add_no_format(
+        name="no_fmt2", consumer_name="xyz", description="TESTING NO FORMAT 2"
     )
 
     return nf1, nf2
 
 
-def _add_long_name(df: DLISFile) -> eflr_types.LongNameItem:
-    ln = df.add_long_name(
+def _add_long_name(lf: LogicalFile) -> eflr_types.LongNameItem:
+    ln = lf.add_long_name(
         name="LNAME-1",
         general_modifier=["SOME ASCII TEXT"],
         quantity="SOME ASCII TEXT",
@@ -507,68 +546,74 @@ def _add_long_name(df: DLISFile) -> eflr_types.LongNameItem:
         source_part_number=["SOME ASCII TEXT"],
         conditions=["SOME ASCII TEXT"],
         standard_symbol="SOME ASCII TEXT",
-        private_symbol="SOME ASCII TEXT"
+        private_symbol="SOME ASCII TEXT",
     )
 
     return ln
 
 
-def _add_groups(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...],
-                processes: tuple[eflr_types.ProcessItem, ...]) -> tuple[eflr_types.GroupItem, ...]:
-    g1 = df.add_group(
+def _add_groups(
+    lf: LogicalFile,
+    channels: tuple[eflr_types.ChannelItem, ...],
+    processes: tuple[eflr_types.ProcessItem, ...],
+) -> tuple[eflr_types.GroupItem, ...]:
+    g1 = lf.add_group(
         name="ChannelGroup",
         description="Group of channels",
-        object_list=[channels[1], channels[2]]
+        object_list=[channels[1], channels[2]],
     )
 
-    g2 = df.add_group(
+    g2 = lf.add_group(
         name="ProcessGroup",
         description="Group of processes",
-        object_list=[processes[0], processes[1]]
+        object_list=[processes[0], processes[1]],
     )
 
-    g3 = df.add_group(
-        name="MultiGroup",
-        description="Group of groups",
-        group_list=[g1, g2]
+    g3 = lf.add_group(
+        name="MultiGroup", description="Group of groups", group_list=[g1, g2]
     )
 
-    g4 = df.add_group(
+    g4 = lf.add_group(
         name="Mixed-group",
         description="Mixed objects",
         object_list=[channels[4], channels[5], processes[1]],
-        group_list=[g1, g3]
+        group_list=[g1, g3],
     )
 
     return g1, g2, g3, g4
 
 
 def create_dlis_file_object() -> DLISFile:
-    df = DLISFile(storage_unit_label=make_sul(), file_header=make_file_header())
-    _add_origin(df)
+    df = DLISFile(storage_unit_label=make_sul())
 
-    axes = _add_axes(df)
-    ln = _add_long_name(df)
-    channels = _add_channels(df, axes[0], ln)
-    frame = _add_frame(df, *channels[4:9])
-    zones = _add_zones(df)
-    params = _add_parameters(df, zones, ln)
-    equipment = _add_equipment(df)
-    tools = _add_tools(df, equipment, params, channels)
-    computations = _add_computation(df, axes, zones, tools, ln)
-    processes = _add_processes(df, params, channels, computations)
-    _add_splices(df, channels, zones)
-    _add_calibrations(df, axes, channels, params)
-    wrp = _add_well_reference_points(df)
-    _add_paths(df, frame, wrp[0], channels)
-    _add_messages(df)
-    _add_comments(df)
-    _add_no_formats(df)
-    _add_groups(df, channels, processes)
+    lf = df.add_logical_file(file_header=make_file_header())
+
+    _add_origin(lf)
+
+    axes = _add_axes(lf)
+    ln = _add_long_name(lf)
+    channels = _add_channels(lf, axes[0], ln)
+    frame = _add_frame(lf, *channels[4:9])
+    zones = _add_zones(lf)
+    params = _add_parameters(lf, zones, ln)
+    equipment = _add_equipment(lf)
+    tools = _add_tools(lf, equipment, params, channels)
+    computations = _add_computation(lf, axes, zones, tools, ln)
+    processes = _add_processes(lf, params, channels, computations)
+    _add_splices(lf, channels, zones)
+    _add_calibrations(lf, axes, channels, params)
+    wrp = _add_well_reference_points(lf)
+    _add_paths(lf, frame, wrp[0], channels)
+    _add_messages(lf)
+    _add_comments(lf)
+    _add_no_formats(lf)
+    _add_groups(lf, channels, processes)
 
     return df
 
 
-def write_short_dlis(fname: Union[str, os.PathLike[str]], data: Union[dict, os.PathLike[str], np.ndarray]) -> None:
+def write_short_dlis(
+    fname: Union[str, os.PathLike[str]], data: Union[dict, os.PathLike[str], np.ndarray]
+) -> None:
     df = create_dlis_file_object()
     df.write(fname, data=data)

--- a/src/tests/dlis_files_for_testing/time_based_dlis.py
+++ b/src/tests/dlis_files_for_testing/time_based_dlis.py
@@ -9,51 +9,49 @@ from dliswriter.utils.enums import Unit
 from tests.dlis_files_for_testing.common import make_df
 
 
-def _add_channels(df: DLISFile) -> tuple[eflr_types.ChannelItem, ...]:
-    ch_time = df.add_channel(
+def _add_channels(df: DLISFile, lf: int) -> tuple[eflr_types.ChannelItem, ...]:
+    ch_time = df.logical_files[lf].add_channel(
         name="posix time",
         dataset_name="/contents/time",
         units=Unit.SECOND,
         cast_dtype=np.float64,
-        dimension=[1]
+        dimension=[1],
     )
 
-    ch_rpm = df.add_channel(
+    ch_rpm = df.logical_files[lf].add_channel(
         name="surface rpm",
         dataset_name="contents/rpm",
         cast_dtype=np.float64,
     )
 
-    ch_amp = df.add_channel(
-        name="amplitude",
-        dataset_name="contents/image0",
-        cast_dtype=np.float32
+    ch_amp = df.logical_files[lf].add_channel(
+        name="amplitude", dataset_name="contents/image0", cast_dtype=np.float32
     )
 
-    ch_radius = df.add_channel(
+    ch_radius = df.logical_files[lf].add_channel(
         name="radius",
         dataset_name="/contents/image1",
         dimension=[128],
         units=Unit.INCH,
-        cast_dtype=np.float32
+        cast_dtype=np.float32,
     )
 
-    ch_radius_pooh = df.add_channel(
+    ch_radius_pooh = df.logical_files[lf].add_channel(
         name="radius_pooh",
         dataset_name="contents/image2",
         dimension=[128],
         units="m",
-        cast_dtype=np.float32
+        cast_dtype=np.float32,
     )
 
     return ch_time, ch_rpm, ch_amp, ch_radius, ch_radius_pooh
 
 
-def _add_frame(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...]) -> eflr_types.FrameItem:
-    fr = df.add_frame(
-        name="MAIN",
-        index_type="TIME",
-        channels=channels
+def _add_frame(
+    df: DLISFile, lf: int, channels: tuple[eflr_types.ChannelItem, ...]
+) -> eflr_types.FrameItem:
+    fr = df.logical_files[lf].add_frame(
+        name="MAIN", index_type="TIME", channels=channels
     )
 
     fr.spacing.units = "s"
@@ -64,13 +62,17 @@ def _add_frame(df: DLISFile, channels: tuple[eflr_types.ChannelItem, ...]) -> ef
 def create_dlis_file_object() -> DLISFile:
     df = make_df()
 
-    channels = _add_channels(df)
-    _add_frame(df, channels)
+    logical_file_index = 0
+    channels = _add_channels(df, logical_file_index)
+    _add_frame(df, logical_file_index, channels)
 
     return df
 
 
-def write_time_based_dlis(fname: Union[str, os.PathLike[str]], data: Union[dict, os.PathLike[str], np.ndarray],
-                          **kwargs: Any) -> None:
+def write_time_based_dlis(
+    fname: Union[str, os.PathLike[str]],
+    data: Union[dict, os.PathLike[str], np.ndarray],
+    **kwargs: Any,
+) -> None:
     df = create_dlis_file_object()
     df.write(fname, data=data, **kwargs)

--- a/src/tests/test_file/test_channels_in_file.py
+++ b/src/tests/test_file/test_channels_in_file.py
@@ -7,20 +7,23 @@ from dliswriter import DLISFile, high_compatibility_mode_decorator, enums
 
 def _prepare_file_channel_not_in_frame() -> DLISFile:
     df = DLISFile()
-    df.add_origin("ORIGIN")
-    ch1 = df.add_channel("INDEX", data=np.arange(10))
-    df.add_channel("X", units="m", data=np.random.rand(10, 10))  # not added to frame
-    ch3 = df.add_channel("Y", data=np.arange(10, 20))
-    df.add_frame("MAIN", channels=(ch1, ch3), index_type=enums.FrameIndexType.NON_STANDARD)
+    lf = df.add_logical_file()
+    lf.add_origin("ORIGIN")
+    ch1 = lf.add_channel("INDEX", data=np.arange(10))
+    lf.add_channel("X", units="m", data=np.random.rand(10, 10))  # not added to frame
+    ch3 = lf.add_channel("Y", data=np.arange(10, 20))
+    lf.add_frame(
+        "MAIN", channels=(ch1, ch3), index_type=enums.FrameIndexType.NON_STANDARD
+    )
 
     return df
 
 
 def test_channel_not_in_frame(caplog: pytest.LogCaptureFixture) -> None:
 
-    with caplog.at_level(logging.WARNING, logger='dliswriter'):
+    with caplog.at_level(logging.WARNING, logger="dliswriter"):
         df = _prepare_file_channel_not_in_frame()
-        df.check_objects()
+        df.logical_files[0].check_objects()
         assert "ChannelItem 'X' has not been added to any frame" in caplog.text
 
 
@@ -28,30 +31,33 @@ def test_channel_not_in_frame(caplog: pytest.LogCaptureFixture) -> None:
 def test_channel_not_in_frame_high_compat_mode() -> None:
     df = _prepare_file_channel_not_in_frame()
 
-    with pytest.raises(RuntimeError, match="ChannelItem 'X' has not been added to any frame.*"):
-        df.check_objects()
+    with pytest.raises(
+        RuntimeError, match="ChannelItem 'X' has not been added to any frame.*"
+    ):
+        df.logical_files[0].check_objects()
 
 
 def _prepare_file_channel_in_multiple_frames() -> DLISFile:
     df = DLISFile()
-    df.add_origin("ORIGIN")
-    ch_a = df.add_channel("A")  # in 3 frames
-    ch_b = df.add_channel("B")
-    ch_c = df.add_channel("C")  # in 2 frames
-    ch_d = df.add_channel("D")
+    lf = df.add_logical_file()
+    lf.add_origin("ORIGIN")
+    ch_a = lf.add_channel("A")  # in 3 frames
+    ch_b = lf.add_channel("B")
+    ch_c = lf.add_channel("C")  # in 2 frames
+    ch_d = lf.add_channel("D")
 
-    df.add_frame("MAIN", channels=(ch_a, ch_c))
-    df.add_frame("F2", channels=(ch_a, ch_b))
-    df.add_frame("F3", channels=(ch_a, ch_c, ch_d))
+    lf.add_frame("MAIN", channels=(ch_a, ch_c))
+    lf.add_frame("F2", channels=(ch_a, ch_b))
+    lf.add_frame("F3", channels=(ch_a, ch_c, ch_d))
 
     return df
 
 
 def test_channel_in_multiple_frames(caplog: pytest.LogCaptureFixture) -> None:
 
-    with caplog.at_level(logging.WARNING, logger='dliswriter'):
+    with caplog.at_level(logging.WARNING, logger="dliswriter"):
         df = _prepare_file_channel_in_multiple_frames()
-        df.check_objects()
+        df.logical_files[0].check_objects()
         assert "ChannelItem 'A' has been added to 3 frames" in caplog.text
         assert "ChannelItem 'C' has been added to 2 frames" in caplog.text
 
@@ -60,30 +66,48 @@ def test_channel_in_multiple_frames(caplog: pytest.LogCaptureFixture) -> None:
 def test_channel_in_multiple_frames_high_compat_mode() -> None:
     df = _prepare_file_channel_in_multiple_frames()
 
-    with pytest.raises(RuntimeError, match="ChannelItem 'A' has been added to 3 frames.*"):
-        df.check_objects()
+    with pytest.raises(
+        RuntimeError, match="ChannelItem 'A' has been added to 3 frames.*"
+    ):
+        df.logical_files[0].check_objects()
 
 
 def _prepare_file_with_sint_data() -> DLISFile:
     df = DLISFile()
-    df.add_origin("ORIGIN")
-    ch1 = df.add_channel("INDEX", data=np.arange(10), cast_dtype=np.uint8)
-    ch2 = df.add_channel("X", data=np.arange(-10, 20).astype(np.int16))
-    ch3 = df.add_channel("Y", data=np.random.randint(-10, 11, size=(10, 20)), cast_dtype=np.int32)
-    ch4 = df.add_channel("Z", data=np.arange(10), cast_dtype=np.int8)
-    df.add_frame("MAIN", channels=(ch1, ch2, ch3, ch4), index_type=enums.FrameIndexType.NON_STANDARD)
+    lf = df.add_logical_file()
+    lf.add_origin("ORIGIN")
+    ch1 = lf.add_channel("INDEX", data=np.arange(10), cast_dtype=np.uint8)
+    ch2 = lf.add_channel("X", data=np.arange(-10, 20).astype(np.int16))
+    ch3 = lf.add_channel(
+        "Y", data=np.random.randint(-10, 11, size=(10, 20)), cast_dtype=np.int32
+    )
+    ch4 = lf.add_channel("Z", data=np.arange(10), cast_dtype=np.int8)
+    lf.add_frame(
+        "MAIN",
+        channels=(ch1, ch2, ch3, ch4),
+        index_type=enums.FrameIndexType.NON_STANDARD,
+    )
 
     return df
 
 
 def test_sint_data(caplog: pytest.LogCaptureFixture) -> None:
 
-    with caplog.at_level(logging.WARNING, logger='dliswriter'):
+    with caplog.at_level(logging.WARNING, logger="dliswriter"):
         df = _prepare_file_with_sint_data()
         df.generate_logical_records(None)
-        assert "Data type of channel 'X' is int16; some DLIS viewers cannot interpret signed integers" in caplog.text
-        assert "Data type of channel 'Y' is int32; some DLIS viewers cannot interpret signed integers" in caplog.text
-        assert "Data type of channel 'Z' is int8; some DLIS viewers cannot interpret signed integers" in caplog.text
+        assert (
+            "Data type of channel 'X' is int16; some DLIS viewers cannot interpret signed integers"
+            in caplog.text
+        )
+        assert (
+            "Data type of channel 'Y' is int32; some DLIS viewers cannot interpret signed integers"
+            in caplog.text
+        )
+        assert (
+            "Data type of channel 'Z' is int8; some DLIS viewers cannot interpret signed integers"
+            in caplog.text
+        )
 
 
 @high_compatibility_mode_decorator
@@ -91,6 +115,7 @@ def test_sint_data_high_compat_mode() -> None:
     df = _prepare_file_with_sint_data()
 
     with pytest.raises(
-            RuntimeError,
-            match="Data type of channel 'X' is int16; some DLIS viewers cannot interpret signed integers.*"):
+        RuntimeError,
+        match="Data type of channel 'X' is int16; some DLIS viewers cannot interpret signed integers.*",
+    ):
         df.generate_logical_records(None)

--- a/src/tests/test_file/test_double_frame.py
+++ b/src/tests/test_file/test_double_frame.py
@@ -11,48 +11,52 @@ from tests.common import load_dlis
 from tests.dlis_files_for_testing.double_frame_dlis import write_double_frame_dlis
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def double_frame_data() -> tuple[dict, dict]:
     n_rows_1 = 100
     n_rows_2 = 200
 
     frame1_data = {
-        'DEPTH': np.arange(n_rows_1),
-        'RPM': 10 * np.random.rand(n_rows_1),
-        'AMPLITUDE': np.random.rand(n_rows_1, 10),
+        "DEPTH": np.arange(n_rows_1),
+        "RPM": 10 * np.random.rand(n_rows_1),
+        "AMPLITUDE": np.random.rand(n_rows_1, 10),
     }
 
     frame2_data = {
-        'DEPTH': np.arange(n_rows_2) / 10,
-        'RPM': (np.arange(n_rows_2) % 10).astype(np.int32),
-        'AMPLITUDE': np.arange(n_rows_2 * 5).reshape(n_rows_2, 5) % 6
+        "DEPTH": np.arange(n_rows_2) / 10,
+        "RPM": (np.arange(n_rows_2) % 10).astype(np.int32),
+        "AMPLITUDE": np.arange(n_rows_2 * 5).reshape(n_rows_2, 5) % 6,
     }
 
     return frame1_data, frame2_data
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def double_frame_dlis_path(base_data_path: Path) -> Generator:
-    p = base_data_path/'double_frame.DLIS'
+    p = base_data_path / "double_frame.DLIS"
     yield p
 
     if p.exists():
         os.remove(p)
 
 
-@pytest.fixture(scope='session')
-def double_frame_dlis(double_frame_dlis_path: Path, double_frame_data: tuple[dict, dict]) -> Generator:
+@pytest.fixture(scope="session")
+def double_frame_dlis(
+    double_frame_dlis_path: Path, double_frame_data: tuple[dict, dict]
+) -> Generator:
     df = write_double_frame_dlis(double_frame_dlis_path, *double_frame_data)
     yield df
 
 
-@pytest.fixture(scope='session')
-def double_frame_dlis_contents(double_frame_dlis_path: Path, double_frame_dlis: DLISFile) -> dlis.LogicalFile:
+@pytest.fixture(scope="session")
+def double_frame_dlis_contents(
+    double_frame_dlis_path: Path, double_frame_dlis: DLISFile
+) -> dlis.LogicalFile:
     with load_dlis(double_frame_dlis_path) as f:
         yield f
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def channels(double_frame_dlis_contents: dlis.LogicalFile) -> list[dlis.Channel]:
     return double_frame_dlis_contents.channels  # type: ignore  # return type not recognised
 
@@ -61,9 +65,9 @@ def test_channel_names(channels: list[dlis.Channel]) -> None:
     assert len(channels) == 6
 
     names = [c.name for c in channels]
-    assert names.count('DEPTH') == 2
-    assert names.count('RPM') == 2
-    assert names.count('AMPLITUDE') == 2
+    assert names.count("DEPTH") == 2
+    assert names.count("RPM") == 2
+    assert names.count("AMPLITUDE") == 2
 
 
 def test_channel_copy_numbers(channels: list[dlis.Channel]) -> None:
@@ -72,78 +76,100 @@ def test_channel_copy_numbers(channels: list[dlis.Channel]) -> None:
     assert cn.count(1) == 3
 
 
-@pytest.mark.parametrize('nr', (0, 1))
+@pytest.mark.parametrize("nr", (0, 1))
 def test_frame_channels(double_frame_dlis_contents: dlis.LogicalFile, nr: int) -> None:
     frame = double_frame_dlis_contents.frames[nr]
-    assert frame.copynumber == 0  # frames have different names, so can have the same copy number
+    assert (
+        frame.copynumber == 0
+    )  # frames have different names, so can have the same copy number
 
     ch = frame.channels
     assert len(ch) == 3
 
-    assert ch[0].name == 'DEPTH'
-    assert ch[1].name == 'RPM'
-    assert ch[2].name == 'AMPLITUDE'
+    assert ch[0].name == "DEPTH"
+    assert ch[1].name == "RPM"
+    assert ch[2].name == "AMPLITUDE"
 
     for ch in ch:
         assert ch.copynumber == nr
 
 
-@pytest.mark.parametrize('nr', (0, 1))
-def test_frame_data(double_frame_dlis_contents: dlis.LogicalFile, double_frame_data: tuple[dict, dict],
-                    nr: int) -> None:
+@pytest.mark.parametrize("nr", (0, 1))
+def test_frame_data(
+    double_frame_dlis_contents: dlis.LogicalFile,
+    double_frame_data: tuple[dict, dict],
+    nr: int,
+) -> None:
 
     frame_channels = double_frame_dlis_contents.frames[nr].channels
     data = double_frame_data[nr]
 
-    assert (frame_channels[0].curves() == data['DEPTH']).all()
-    assert (frame_channels[1].curves() == data['RPM']).all()
-    assert (frame_channels[2].curves() == data['AMPLITUDE']).all()
+    assert (frame_channels[0].curves() == data["DEPTH"]).all()
+    assert (frame_channels[1].curves() == data["RPM"]).all()
+    assert (frame_channels[2].curves() == data["AMPLITUDE"]).all()
 
 
 def test_dataset_names(double_frame_dlis: DLISFile) -> None:
-    file_channels = double_frame_dlis.channels
+    file_channels = double_frame_dlis.logical_files[0].channels
 
-    assert file_channels[0].dataset_name == 'DEPTH'
-    assert file_channels[1].dataset_name == 'RPM'
-    assert file_channels[2].dataset_name == 'AMPLITUDE'
+    assert file_channels[0].dataset_name == "DEPTH"
+    assert file_channels[1].dataset_name == "RPM"
+    assert file_channels[2].dataset_name == "AMPLITUDE"
 
-    assert file_channels[3].dataset_name == 'DEPTH__1'
-    assert file_channels[4].dataset_name == 'RPM__1'
-    assert file_channels[5].dataset_name == 'AMPLITUDE__1'
+    assert file_channels[3].dataset_name == "DEPTH__1"
+    assert file_channels[4].dataset_name == "RPM__1"
+    assert file_channels[5].dataset_name == "AMPLITUDE__1"
 
-    assert all(dn in double_frame_dlis._data_dict for dn in (
-        'DEPTH', 'RPM', 'AMPLITUDE', 'DEPTH__1', 'RPM__1', 'AMPLITUDE__1'
-    ))
+    assert all(
+        dn in double_frame_dlis.logical_files[0]._data_dict
+        for dn in ("DEPTH", "RPM", "AMPLITUDE", "DEPTH__1", "RPM__1", "AMPLITUDE__1")
+    )
 
 
-@pytest.mark.parametrize(("channel_name", "dataset_name"), (("DEPTH", "depth"), ("XYZ", "XZY")))
+@pytest.mark.parametrize(
+    ("channel_name", "dataset_name"), (("DEPTH", "depth"), ("XYZ", "XZY"))
+)
 def test_unique_dataset_name_from_dataset_name(
-        double_frame_dlis: DLISFile, channel_name: str, dataset_name: str) -> None:
+    double_frame_dlis: DLISFile, channel_name: str, dataset_name: str
+) -> None:
 
-    ch = double_frame_dlis.add_channel(channel_name, dataset_name=dataset_name)
+    ch = double_frame_dlis.logical_files[0].add_channel(
+        channel_name, dataset_name=dataset_name
+    )
     assert ch.dataset_name == dataset_name
 
 
-@pytest.mark.parametrize(("channel_name", "dataset_name"), (("RPM", "RPM"), ("new_channel", "AMPLITUDE")))
+@pytest.mark.parametrize(
+    ("channel_name", "dataset_name"), (("RPM", "RPM"), ("new_channel", "AMPLITUDE"))
+)
 def test_unique_dataset_name_but_dataset_name_exists(
-        double_frame_dlis: DLISFile, channel_name: str, dataset_name: str) -> None:
+    double_frame_dlis: DLISFile, channel_name: str, dataset_name: str
+) -> None:
 
-    with pytest.raises(ValueError, match=f"A data set with name '{dataset_name}' already exists"):
-        double_frame_dlis.add_channel(channel_name, dataset_name=dataset_name)
+    with pytest.raises(
+        ValueError, match=f"A data set with name '{dataset_name}' already exists"
+    ):
+        double_frame_dlis.logical_files[0].add_channel(
+            channel_name, dataset_name=dataset_name
+        )
 
 
 @pytest.mark.parametrize("channel_name", ("NEW_CHANNEL", "XXX"))
-def test_unique_dataset_name_from_new_channel_name(double_frame_dlis: DLISFile, channel_name: str) -> None:
+def test_unique_dataset_name_from_new_channel_name(
+    double_frame_dlis: DLISFile, channel_name: str
+) -> None:
 
-    ch = double_frame_dlis.add_channel(channel_name)
+    ch = double_frame_dlis.logical_files[0].add_channel(channel_name)
     assert ch.dataset_name == channel_name
 
 
 @pytest.mark.parametrize("channel_name", ("ABC", "SURFACE_RPM"))
-def test_unique_dataset_name_from_repeated_channel_name(double_frame_dlis: DLISFile, channel_name: str) -> None:
+def test_unique_dataset_name_from_repeated_channel_name(
+    double_frame_dlis: DLISFile, channel_name: str
+) -> None:
     chs = []
     for i in range(5):
-        chs.append(double_frame_dlis.add_channel(channel_name))
+        chs.append(double_frame_dlis.logical_files[0].add_channel(channel_name))
 
     assert chs[0].name == channel_name
     assert chs[0].dataset_name == channel_name
@@ -161,7 +187,9 @@ def test_multiple_axes(double_frame_dlis_contents: dlis.LogicalFile) -> None:
         axes = frames[i].channels[0].axis
         assert len(axes) == 1
         axis = axes[0]
-        assert axis.name == 'AXIS'
+        assert axis.name == "AXIS"
         assert axis.copynumber == i
 
-    assert frames[0].channels[0].axis[0] is not frames[1].channels[0].axis[0]  # separate objects
+    assert (
+        frames[0].channels[0].axis[0] is not frames[1].channels[0].axis[0]
+    )  # separate objects

--- a/src/tests/test_file/test_double_frame.py
+++ b/src/tests/test_file/test_double_frame.py
@@ -17,15 +17,15 @@ def double_frame_data() -> tuple[dict, dict]:
     n_rows_2 = 200
 
     frame1_data = {
-        "DEPTH": np.arange(n_rows_1),
-        "RPM": 10 * np.random.rand(n_rows_1),
+        "DEPTH": np.arange(start=0, stop=n_rows_1, dtype=np.uint32),
+        "RPM": (10 * np.random.rand(n_rows_1)).astype(np.float32),
         "AMPLITUDE": np.random.rand(n_rows_1, 10),
     }
 
     frame2_data = {
-        "DEPTH": np.arange(n_rows_2) / 10,
-        "RPM": (np.arange(n_rows_2) % 10).astype(np.int32),
-        "AMPLITUDE": np.arange(n_rows_2 * 5).reshape(n_rows_2, 5) % 6,
+        "DEPTH": (np.arange(start=0, stop=n_rows_2) / 10).astype(np.uint32),
+        "RPM": (np.arange(n_rows_2) % 10).astype(np.float32),
+        "AMPLITUDE": (np.arange(n_rows_2 * 5).reshape(n_rows_2, 5) % 6).astype(np.float32),
     }
 
     return frame1_data, frame2_data

--- a/src/tests/test_file/test_origin_options.py
+++ b/src/tests/test_file/test_origin_options.py
@@ -4,34 +4,40 @@ from tests.dlis_files_for_testing.common import make_sul, make_file_header
 
 
 def test_adding_origin_after_other_objects() -> None:
-    df = DLISFile(storage_unit_label=make_sul(), file_header=make_file_header())
+    df = DLISFile(storage_unit_label=make_sul())
+    lf = df.add_logical_file(file_header=make_file_header())
 
-    ch_depth = df.add_channel(name="depth")
-    ch_rpm = df.add_channel(name="surface rpm")
+    ch_depth = lf.add_channel(name="depth")
+    ch_rpm = lf.add_channel(name="surface rpm")
 
-    assert df.default_origin_reference is None
-    origin = df.add_origin("DEFINING ORIGIN", file_set_number=38)
-    assert df.default_origin_reference == 38
+    assert lf.default_origin_reference is None
+    origin = lf.add_origin("DEFINING ORIGIN", file_set_number=38)
+    assert lf.default_origin_reference == 0
 
-    ch_time = df.add_channel('time')
-    frame = df.add_frame("MAIN FRAME", channels=(ch_time, ch_rpm, ch_depth))
+    ch_time = lf.add_channel("time")
+    frame = lf.add_frame("MAIN FRAME", channels=(ch_time, ch_rpm, ch_depth))
 
     for obj in (ch_time, ch_rpm, ch_depth, frame, origin):
-        assert obj.origin_reference == 38
+        assert obj.origin_reference == 0
 
 
 def test_specifying_other_origin_reference() -> None:
-    df = DLISFile(storage_unit_label=make_sul(), file_header=make_file_header())
+    df = DLISFile(storage_unit_label=make_sul())
+    lf = df.add_logical_file(file_header=make_file_header())
 
-    ch_depth = df.add_channel(name="depth")
-    ch_rpm = df.add_channel(name="surface rpm", origin_reference=22)
+    ch_depth = lf.add_channel(name="depth")
+    ch_rpm = lf.add_channel(name="surface rpm", origin_reference=22)
 
-    origin = df.add_origin("DEFINING ORIGIN", file_set_number=38)
+    origin = lf.add_origin("DEFINING ORIGIN", origin_reference=38)
 
-    ch_time = df.add_channel('time', origin_reference=15)
-    ch_x = df.add_channel('x')
-    frame = df.add_frame("MAIN FRAME", channels=(ch_time, ch_rpm, ch_depth, ch_x), origin_reference=10)
+    ch_time = lf.add_channel("time", origin_reference=15)
+    ch_x = lf.add_channel("x")
+    frame = lf.add_frame(
+        "MAIN FRAME", channels=(ch_time, ch_rpm, ch_depth, ch_x), origin_reference=10
+    )
 
+    # Items created before the logical file's defining origin (i.e., the first origin) assume the defining origin's origin_reference
+    # value when it is created. This value is also assigned to items created after the defining origin with no origin_reference as creation argument
     for obj in (ch_depth, ch_x, origin):
         assert obj.origin_reference == 38
 
@@ -41,30 +47,28 @@ def test_specifying_other_origin_reference() -> None:
 
 
 def test_multiple_origins() -> None:
-    df = DLISFile(storage_unit_label=make_sul(), file_header=make_file_header())
+    df = DLISFile(storage_unit_label=make_sul())
+    lf = df.add_logical_file(file_header=make_file_header())
 
-    assert df.default_origin_reference is None
-    origin1 = df.add_origin("MAIN ORIGIN", file_set_number=23)
-    assert df.default_origin_reference == 23
-    axis1 = df.add_axis('AX1')
-    ch1 = df.add_channel('rpm')
+    assert lf.default_origin_reference is None
+    origin1 = lf.add_origin("MAIN ORIGIN", origin_reference=23)
+    assert lf.default_origin_reference == 23
+    axis1 = lf.add_axis("AX1")
+    ch1 = lf.add_channel("rpm")
 
-    origin2 = df.add_origin("ADDITIONAL ORIGIN", file_set_number=11)
-    comp1 = df.add_computation("comp1", origin_reference=origin2.file_set_number.value)
-    comp2 = df.add_computation("comp2")  # should have origin1 as reference
-    assert df.default_origin_reference == 23
+    origin2 = lf.add_origin("ADDITIONAL ORIGIN", origin_reference=11)
+    comp1 = lf.add_computation("comp1", origin_reference=origin2.origin_reference)
+    comp2 = lf.add_computation("comp2")  # should have origin1 as reference
+    assert lf.default_origin_reference == 23
 
-    origin3 = df.add_origin("ANOTHER ORIGIN")
-    param1 = df.add_parameter("PARAM1", origin_reference=11)  # origin2
-    param2 = df.add_parameter("PARAM2")  # origin1
-    param3 = df.add_parameter("PARAM3", origin_reference=origin3.file_set_number.value)
-    assert df.default_origin_reference == 23
+    origin3 = lf.add_origin("ANOTHER ORIGIN")
+    param1 = lf.add_parameter("PARAM1", origin_reference=11)  # origin2
+    param2 = lf.add_parameter("PARAM2")  # origin1
+    param3 = lf.add_parameter("PARAM3", origin_reference=origin3.origin_reference)
+    assert lf.default_origin_reference == 23
 
     for obj in (origin1, axis1, ch1, comp2, param2):
         assert obj.origin_reference == 23
 
     for obj in (origin2, comp1, param1):
         assert obj.origin_reference == 11
-
-    for obj in (origin3, param3):
-        assert obj.origin_reference == origin3.file_set_number.value

--- a/src/tests/test_file/test_origin_options.py
+++ b/src/tests/test_file/test_origin_options.py
@@ -36,8 +36,9 @@ def test_specifying_other_origin_reference() -> None:
         "MAIN FRAME", channels=(ch_time, ch_rpm, ch_depth, ch_x), origin_reference=10
     )
 
-    # Items created before the logical file's defining origin (i.e., the first origin) assume the defining origin's origin_reference
-    # value when it is created. This value is also assigned to items created after the defining origin with no origin_reference as creation argument
+    # Items created before the logical file's defining origin (i.e., the first origin) assume the defining origin's
+    # origin_reference value when it is created. This value is also assigned to items created after the defining
+    # origin with no origin_reference as creation argument
     for obj in (ch_depth, ch_x, origin):
         assert obj.origin_reference == 38
 
@@ -61,10 +62,8 @@ def test_multiple_origins() -> None:
     comp2 = lf.add_computation("comp2")  # should have origin1 as reference
     assert lf.default_origin_reference == 23
 
-    origin3 = lf.add_origin("ANOTHER ORIGIN")
     param1 = lf.add_parameter("PARAM1", origin_reference=11)  # origin2
     param2 = lf.add_parameter("PARAM2")  # origin1
-    param3 = lf.add_parameter("PARAM3", origin_reference=origin3.origin_reference)
     assert lf.default_origin_reference == 23
 
     for obj in (origin1, axis1, ch1, comp2, param2):

--- a/src/tests/test_logical_record/test_eflr_types/test_frame.py
+++ b/src/tests/test_logical_record/test_eflr_types/test_frame.py
@@ -14,38 +14,35 @@ def test_frame_creation() -> None:
     frame = FrameItem(
         "MAIN-FRAME",
         **{
-            'index_type': 'BOREHOLE-DEPTH',
-            'encrypted': 1,
-            'description': "The main frame",
-            'spacing': {'value': 0.2, 'units': 'm'}
+            "index_type": "BOREHOLE-DEPTH",
+            "encrypted": 1,
+            "description": "The main frame",
+            "spacing": {"value": 0.2, "units": "m"},
         },
-        parent=FrameSet()
+        parent=FrameSet(),
     )
 
-    assert frame.name == 'MAIN-FRAME'
-    assert frame.index_type.value == 'BOREHOLE-DEPTH'
+    assert frame.name == "MAIN-FRAME"
+    assert frame.index_type.value == "BOREHOLE-DEPTH"
     assert frame.encrypted.value == 1
-    assert frame.description.value == 'The main frame'
+    assert frame.description.value == "The main frame"
 
     assert frame.spacing.value == 0.2
-    assert frame.spacing.units == 'm'
+    assert frame.spacing.units == "m"
     assert frame.spacing.representation_code is RepresentationCode.FDOUBL
 
     assert isinstance(frame.parent, FrameSet)
     assert frame.parent.set_name is None
 
 
-@pytest.mark.parametrize("channel_names", (
-        ("Channel 1", "Channel 3", "Channel 2"),
-        ("some_channel",)
-))
+@pytest.mark.parametrize(
+    "channel_names", (("Channel 1", "Channel 3", "Channel 2"), ("some_channel",))
+)
 def test_creation_with_channels(channel_names: tuple[str], channels: dict) -> None:
     """Test creating a FrameObject with specified channels."""
 
     frame = FrameItem(
-        'Some frame',
-        channels=[channels[k] for k in channel_names],
-        parent=FrameSet()
+        "Some frame", channels=[channels[k] for k in channel_names], parent=FrameSet()
     )
 
     assert frame.channels.value is not None
@@ -57,16 +54,19 @@ def test_creation_with_channels(channel_names: tuple[str], channels: dict) -> No
 
 def _prepare_file_uneven_spacing() -> DLISFile:
     df = DLISFile()
-    ch1 = df.add_channel("INDEX", data=np.arange(10) + np.random.rand(10))
-    ch2 = df.add_channel("X", units="m", data=np.random.rand(10, 10))
-    df.add_frame("MAIN", channels=(ch1, ch2), index_type=enums.FrameIndexType.NON_STANDARD)
+    lf = df.add_logical_file()
+    ch1 = lf.add_channel("INDEX", data=np.arange(10) + np.random.rand(10))
+    ch2 = lf.add_channel("X", units="m", data=np.random.rand(10, 10))
+    lf.add_frame(
+        "MAIN", channels=(ch1, ch2), index_type=enums.FrameIndexType.NON_STANDARD
+    )
     return df
 
 
 def test_spacing_not_even(caplog: pytest.LogCaptureFixture) -> None:
     df = _prepare_file_uneven_spacing()
 
-    with caplog.at_level(logging.WARNING, logger='dliswriter'):
+    with caplog.at_level(logging.WARNING, logger="dliswriter"):
         df.generate_logical_records(chunk_size=None)
         assert "Spacing of the index channel" in caplog.text
 
@@ -75,22 +75,29 @@ def test_spacing_not_even(caplog: pytest.LogCaptureFixture) -> None:
 def test_spacing_not_even_high_compat_mode() -> None:
     df = _prepare_file_uneven_spacing()
 
-    with pytest.raises(RuntimeError, match="Spacing of the index channel .* is not uniform.*"):
+    with pytest.raises(
+        RuntimeError, match="Spacing of the index channel .* is not uniform.*"
+    ):
         df.generate_logical_records(chunk_size=None)
 
 
-def _prepare_file_first_channel_2d(index_type: Optional[enums.FrameIndexType] = None) -> DLISFile:
+def _prepare_file_first_channel_2d(
+    index_type: Optional[enums.FrameIndexType] = None,
+) -> DLISFile:
     df = DLISFile()
-    ch1 = df.add_channel("INDEX", data=np.arange(24).reshape(12, 2))
-    ch2 = df.add_channel("X", data=np.random.rand(12))
-    ch3 = df.add_channel("Y", data=np.random.randint(0, 10, size=(12, 10)))
-    df.add_frame("F1", channels=(ch1, ch2, ch3), index_type=index_type)
+    lf = df.add_logical_file()
+    ch1 = lf.add_channel("INDEX", data=np.arange(24).reshape(12, 2))
+    ch2 = lf.add_channel("X", data=np.random.rand(12))
+    ch3 = lf.add_channel("Y", data=np.random.randint(0, 10, size=(12, 10)))
+    lf.add_frame("F1", channels=(ch1, ch2, ch3), index_type=index_type)
     return df
 
 
 def test_index_channel_not_1d() -> None:
     df = _prepare_file_first_channel_2d(index_type=enums.FrameIndexType.NON_STANDARD)
-    with pytest.raises(RuntimeError, match="Index channel's data must be 1-dimensional.*"):
+    with pytest.raises(
+        RuntimeError, match="Index channel's data must be 1-dimensional.*"
+    ):
         df.generate_logical_records(chunk_size=None)
 
 

--- a/src/tests/test_logical_record/test_eflr_types/test_frame.py
+++ b/src/tests/test_logical_record/test_eflr_types/test_frame.py
@@ -55,6 +55,7 @@ def test_creation_with_channels(channel_names: tuple[str], channels: dict) -> No
 def _prepare_file_uneven_spacing() -> DLISFile:
     df = DLISFile()
     lf = df.add_logical_file()
+    lf.add_origin("ORIGIN")
     ch1 = lf.add_channel("INDEX", data=np.arange(10) + np.random.rand(10))
     ch2 = lf.add_channel("X", units="m", data=np.random.rand(10, 10))
     lf.add_frame(
@@ -86,9 +87,10 @@ def _prepare_file_first_channel_2d(
 ) -> DLISFile:
     df = DLISFile()
     lf = df.add_logical_file()
-    ch1 = lf.add_channel("INDEX", data=np.arange(24).reshape(12, 2))
+    lf.add_origin("DEFINING ORIGIN")
+    ch1 = lf.add_channel("INDEX", data=np.arange(start=0, stop=24, dtype=np.uint32).reshape(12, 2))
     ch2 = lf.add_channel("X", data=np.random.rand(12))
-    ch3 = lf.add_channel("Y", data=np.random.randint(0, 10, size=(12, 10)))
+    ch3 = lf.add_channel("Y", data=np.random.randint(0, 10, size=(12, 10), dtype=np.int32))
     lf.add_frame("F1", channels=(ch1, ch2, ch3), index_type=index_type)
     return df
 

--- a/src/tests/test_logical_record/test_eflr_types/test_origin.py
+++ b/src/tests/test_logical_record/test_eflr_types/test_origin.py
@@ -10,17 +10,31 @@ from dliswriter import high_compatibility_mode_decorator
 def test_origin_creation() -> None:
     """Test creating OriginItem."""
 
-    origin = OriginItem('DEFAULT ORIGIN', parent=OriginSet(), file_set_number=1, creation_time="2050/03/02 15:30:00",
-                        file_id="WELL ID", file_set_name="Test file set name", file_number=8, run_number=13, well_id=5,
-                        well_name="Test well name", field_name="Test field name", company="Test company")
+    origin = OriginItem(
+        "DEFAULT ORIGIN",
+        parent=OriginSet(),
+        origin_reference=1,
+        file_set_number=1,
+        creation_time="2050/03/02 15:30:00",
+        file_id="WELL ID",
+        file_set_name="Test file set name",
+        file_number=8,
+        run_number=13,
+        well_id=5,
+        well_name="Test well name",
+        field_name="Test field name",
+        company="Test company",
+    )
 
-    assert origin.name == 'DEFAULT ORIGIN'
+    assert origin.name == "DEFAULT ORIGIN"
 
-    assert origin.creation_time.value == datetime(year=2050, month=3, day=2, hour=15, minute=30)
+    assert origin.creation_time.value == datetime(
+        year=2050, month=3, day=2, hour=15, minute=30
+    )
     assert origin.file_id.value == "WELL ID"
     assert origin.file_set_name.value == "Test file set name"
     assert origin.file_set_number.value == 1
-    assert origin.file_number.value == 8
+    assert origin.origin_reference == 1
     assert origin.run_number.value == 13
     assert origin.well_id.value == 5
     assert origin.well_name.value == "Test well name"
@@ -42,18 +56,27 @@ def test_origin_creation() -> None:
 def test_origin_creation_no_dtime_in_attributes() -> None:
     """Test that if creation_time is missing, the origin gets the current date and time as creation time."""
 
-    origin = OriginItem("Some origin name", well_name="Some well name", file_set_number=11, parent=OriginSet())
+    origin = OriginItem(
+        "Some origin name",
+        well_name="Some well name",
+        origin_reference=11,
+        parent=OriginSet(),
+    )
 
     assert origin.name == "Some origin name"
     assert origin.well_name.value == "Some well name"
 
-    assert timedelta(seconds=0) <= datetime.now() - origin.creation_time.value < timedelta(seconds=1)
+    assert (
+        timedelta(seconds=0)
+        <= datetime.now() - origin.creation_time.value
+        < timedelta(seconds=1)
+    )
 
 
 def test_origin_creation_no_attributes() -> None:
     """Test creating OriginItem with minimum number of parameters."""
 
-    origin = OriginItem("Some origin name", parent=OriginSet())
+    origin = OriginItem("Some origin name", origin_reference=1, parent=OriginSet())
 
     assert origin.name == "Some origin name"
     assert origin.well_name.value is None
@@ -62,16 +85,22 @@ def test_origin_creation_no_attributes() -> None:
     assert isinstance(origin.file_set_number.value, int)
     assert 1 <= origin.file_set_number.value <= np.iinfo(np.uint32).max - ULONG_OFFSET
 
-    assert timedelta(seconds=0) <= datetime.now() - origin.creation_time.value < timedelta(seconds=1)
+    assert (
+        timedelta(seconds=0)
+        <= datetime.now() - origin.creation_time.value
+        < timedelta(seconds=1)
+    )
 
     origin.make_item_body_bytes()  # this is where defaults are set
-    assert origin.field_name.value == 'WILDCAT'  # default according to RP66
+    assert origin.field_name.value == "WILDCAT"  # default according to RP66
 
 
 def test_no_reassign_file_set_number() -> None:
-    origin = OriginItem("Some origin name", parent=OriginSet())
+    origin = OriginItem("Some origin name", origin_reference=1, parent=OriginSet())
 
-    with pytest.raises(RuntimeError, match="File set number should not be reassigned.*"):
+    with pytest.raises(
+        RuntimeError, match="File set number should not be reassigned.*"
+    ):
         origin.file_set_number.value = 15
 
 
@@ -79,24 +108,31 @@ def test_no_reassign_file_set_number() -> None:
 def test_file_set_number_high_compat_mode() -> None:
     parent = OriginSet()
 
-    origin1 = OriginItem("ORIGIN", parent=parent)
+    origin1 = OriginItem("ORIGIN", origin_reference=1, parent=parent)
     assert origin1.file_set_number.value == 1
 
-    origin2 = OriginItem("ANOTHER-ORIGIN", parent=parent, file_set_number=15)
+    origin2 = OriginItem(
+        "ANOTHER-ORIGIN", origin_reference=2, parent=parent, file_set_number=15
+    )
     assert origin2.file_set_number.value == 15
 
-    origin3 = OriginItem("ORIG", parent=parent)
+    origin3 = OriginItem("ORIG", origin_reference=3, parent=parent)
     assert origin3.file_set_number.value == 3
 
 
 @pytest.mark.parametrize("name", ("MY-ORIGIN", "ORI_124", "421ORIGIN5"))
 @high_compatibility_mode_decorator
 def test_name_compatible(name: str) -> None:
-    OriginItem(name, parent=OriginSet())  # no error = name accepted, test passed
+    OriginItem(
+        name, origin_reference=1, parent=OriginSet()
+    )  # no error = name accepted, test passed
 
 
 @pytest.mark.parametrize("name", ("Origin", "MY ORIGIN", "ORIGIN.3"))
 @high_compatibility_mode_decorator
 def test_name_not_compatible(name: str) -> None:
-    with pytest.raises(ValueError, match=".*strings can contain only uppercase characters, digits, dashes, .*"):
-        OriginItem(name, parent=OriginSet())
+    with pytest.raises(
+        ValueError,
+        match=".*strings can contain only uppercase characters, digits, dashes, .*",
+    ):
+        OriginItem(name, origin_reference=1, parent=OriginSet())

--- a/src/tests/test_utils/test_converters/test_repr_code_converter.py
+++ b/src/tests/test_utils/test_converters/test_repr_code_converter.py
@@ -54,7 +54,7 @@ def test_determine_repr_code_from_generic_type_not_a_type(t: Any) -> None:
         (-92003198.2, RepresentationCode.FDOUBL),
         (3.123121231, RepresentationCode.FDOUBL),
         ('abc', RepresentationCode.ASCII),
-        (np.arange(10), RepresentationCode.SLONG),
+        (np.arange(start=0, stop=10, dtype=np.int32), RepresentationCode.SLONG),
         (np.random.rand(12, 13), RepresentationCode.FDOUBL)
 ))
 def test_determine_repr_code_from_value_single(v: Any, rc: RepresentationCode) -> None:

--- a/src/tests/test_utils/test_source_data_wrappers/test_dict_data_wrapper.py
+++ b/src/tests/test_utils/test_source_data_wrappers/test_dict_data_wrapper.py
@@ -17,8 +17,8 @@ def data() -> source_data_type:
     n = 100
     d = {
         'depth': np.arange(n) * 0.1,
-        'rpm': (10 * np.random.rand(n)).astype(int),
-        'amplitude': np.random.rand(n, 128).astype(np.float32)
+        'rpm': (10 * np.random.rand(n)).astype(np.int32),
+        'amplitude': np.random.rand(n, 128).astype(np.float32),
     }
 
     return d

--- a/src/tests/test_utils/test_source_data_wrappers/test_numpy_data_wrapper.py
+++ b/src/tests/test_utils/test_source_data_wrappers/test_numpy_data_wrapper.py
@@ -9,7 +9,7 @@ from dliswriter.utils.source_data_wrappers import NumpyDataWrapper, SourceDataWr
 def dtype() -> np.dtype:
     data_types = [
         ('depth', float),
-        ('rpm', int),
+        ('rpm', np.int32),
         ('amplitude', np.float32, 128),
         ('radius', np.int32, 20)
     ]
@@ -30,9 +30,9 @@ def data(dtype: np.dtype) -> np.ndarray:
     n = 50
     arr = np.empty(n, dtype=dtype)
     arr['depth'] = np.arange(n) * 0.01
-    arr['rpm'] = np.random.randint(size=n, low=5, high=10)
+    arr['rpm'] = np.random.randint(size=n, low=5, high=10, dtype=np.int32)
     arr['amplitude'] = np.random.rand(n, 128)
-    arr['radius'] = (10 * np.random.rand(n, 20)).astype(int)
+    arr['radius'] = (10 * np.random.rand(n, 20)).astype(np.int32)
 
     return arr
 


### PR DESCRIPTION
### Summary
- Solved Issue #37 - now we have a Logical File class, and DLISFile have a list of Logical Files. Tested the written files in Log Data Composer, Geolog and GeoSlicer.
- The Origin's `file_set_number` is not used anymore by the `eflr_item`s as the reference to their origin. This could be a bit confusing and didn't met the specification rp66v1. More details on that below
- Adequated the tests to the aforementioned changes
- Adequated the docs
- Other small changes

### Logical Files
* Added `LogicalFile` class. Has almost entirely the contents of the old DLISFile class. The Logical File constitutes the DLIS logical format ("The view of DLIS data that is completely independent of any physical mapping" - rp66v1). A DLIS file can have one or more Logical Files, and these logical files are mutually independent.
* The new `DLISFile` class keeps only the Storage Unit Label, the routines related to file writing, and holds a list of the Logical Files.

### File Set Number and origin reference
The Origin's File Set Number was being used as origin reference, but according to the rp66v1 it _does not_ reference an origin - from the rp66v1 section _5.2.1 Origin of Objects_, we see other usage: all Logical Files of a same File Set (arbitrarily defined) share the same File Set Number. 

* The `origin_reference` attribute of an `eflr_item` now receives at initialization (in file.py) the `origin_reference` of their Origin (_not_the `file_set_number`).
* Again, now file.py's `default_origin_reference()` returns the defining origin's `origin_reference` - _not_ the `file_set_number`
* Added origin_reference parameter to origin creation at file.py's `add_origin(..)` and `OriginItem.init(..)`. And if absent, set it automatically - if the user could pass the `file_set_number`, now one should be able to pass the `origin_reference`
* Origin: Removed obligation of file_set_number being equal to origin_reference 
* `file_set_number` usage in `high_compat_mode` didn't change - written DLIS files opened successfully in Log data Composer

### Other changes
* `file_id` parameter removed from `file.add_origin(..)`. The origin file_id is now set as the file header id of the parent logical file (the logical file that the origin belongs to), abiding to the spec
* I tried to minimize the code formatting differences, but they may still be annoying when inspecting the commit changes...