### PR TITLE
fix #40 - well_id now set as TextAttribute

### DIFF
--- a/docs/userguide/extendingmetadata.rst
+++ b/docs/userguide/extendingmetadata.rst
@@ -29,7 +29,7 @@ The same applies to :ref:`Origin`, which is the container for key meta-data conc
       file_set_name='MY-FILE-SET-NAME',
       file_set_number=11,
       file_number=22,
-      well_id=55,
+      well_id="55",
       well_name='MY-WELL'
     )
 

--- a/src/dliswriter/file/file.py
+++ b/src/dliswriter/file/file.py
@@ -1431,7 +1431,7 @@ class LogicalFile:
         order_number: OptAttrSetupType[str] = None,
         descent_number: OptAttrSetupType[int] = None,
         run_number: OptAttrSetupType[int] = None,
-        well_id: OptAttrSetupType[int] = None,
+        well_id: OptAttrSetupType[str] = None,
         well_name: OptAttrSetupType[str] = None,
         field_name: OptAttrSetupType[str] = None,
         producer_code: OptAttrSetupType[int] = None,

--- a/src/dliswriter/logical_record/eflr_types/origin.py
+++ b/src/dliswriter/logical_record/eflr_types/origin.py
@@ -47,7 +47,7 @@ class OriginItem(EFLRItem):
         self.order_number = TextAttribute('order_number')
         self.descent_number = NumericAttribute('descent_number', representation_code=RepC.UNORM)
         self.run_number = NumericAttribute('run_number', representation_code=RepC.UNORM)
-        self.well_id = NumericAttribute('well_id', representation_code=RepC.UNORM)
+        self.well_id = TextAttribute('well_id')
         self.well_name = TextAttribute('well_name')
         self.field_name = TextAttribute('field_name')
         self.producer_code = NumericAttribute('producer_code', representation_code=RepC.UNORM)

--- a/src/tests/dlis_files_for_testing/short_dlis.py
+++ b/src/tests/dlis_files_for_testing/short_dlis.py
@@ -30,7 +30,7 @@ def _add_origin(lf: LogicalFile) -> eflr_types.OriginItem:
         origin_reference=42,
         file_number=8,
         run_number=13,
-        well_id=5,
+        well_id="5",
         well_name="Test well name",
         field_name="Test field name",
         company="Test company",

--- a/src/tests/test_file/test_eflrs_and_sul/test_origins.py
+++ b/src/tests/test_file/test_eflrs_and_sul/test_origins.py
@@ -21,7 +21,7 @@ def test_origin(short_dlis: dlis.file.LogicalFile) -> None:
     assert origin.origin == 42
     assert origin.file_nr == 8
     assert origin.run_nr == [13]
-    assert origin.well_id == 5
+    assert origin.well_id == "5"
     assert origin.well_name == "Test well name"
     assert origin.field_name == "Test field name"
     assert origin.company == "Test company"

--- a/src/tests/test_logical_record/test_eflr_types/test_origin.py
+++ b/src/tests/test_logical_record/test_eflr_types/test_origin.py
@@ -20,7 +20,7 @@ def test_origin_creation() -> None:
         file_set_name="Test file set name",
         file_number=8,
         run_number=13,
-        well_id=5,
+        well_id="5",
         well_name="Test well name",
         field_name="Test field name",
         company="Test company",
@@ -36,7 +36,7 @@ def test_origin_creation() -> None:
     assert origin.file_set_number.value == 1
     assert origin.origin_reference == 1
     assert origin.run_number.value == 13
-    assert origin.well_id.value == 5
+    assert origin.well_id.value == "5"
     assert origin.well_name.value == "Test well name"
     assert origin.field_name.value == "Test field name"
     assert origin.company.value == "Test company"


### PR DESCRIPTION
I found out that origin.py's `self.well_id` is being initialized with `representation_code=RepC.UNORM`. But some well ids are way larger than 65535 (even greater than RepC.ULONG - 4 bytes) leading to crash at DLIS writing.

For example, an API well number could be 42-501-20130-03-00, wich is 14-digit, plus the dashes (https://esogis.nysm.nysed.gov/american-petroleum-institute-api-number?form=MG0AV3).

Redefining origin's well_id as `self.well_id = TextAttribute('well_id')` solves this.