### PR TITLE
re-writing dlis file opened with dlisio - helper function and example

### DIFF
--- a/examples/create_dlis_from_dlisio.py
+++ b/examples/create_dlis_from_dlisio.py
@@ -1,0 +1,137 @@
+import logging
+from dlisio import dlis    # type: ignore  # untyped library
+import numpy as np
+
+from argparse import ArgumentParser
+from utils import prepare_directory
+# from ..src.dliswriter.utils.import_from_dlisio import create_from_dlisio    # type: ignore  # untyped library
+from dliswriter.utils.import_from_dlisio import create_from_dlisio    # type: ignore  # untyped library
+
+logger = logging.getLogger(__name__)
+
+
+def make_parser() -> ArgumentParser:
+    """Define an argument parser for defining the DLIS file to be created."""
+
+    parser = ArgumentParser("DLIS file creation")
+    parser.add_argument('-ifn', '--input-file-name', help='Intput file name', required=True)
+    parser.add_argument('-ofn', '--output-file-name', help='Output file name', required=True)
+    parser.add_argument('-min', '--minimal-mode', help='If True, a minimal mode is apllyed, writing '
+                        'solely the logical files, origins, frames and channels', required=True)
+
+    return parser
+
+
+def main() -> None:
+    """
+    - This example reads a DLIS file with dlisio and re-writes it with dliswriter
+        - DLIS specification is complex and some files may fail. Note that some users don't need all data.
+        You can call this script with --minimal-mode True to pass along just the logical files, origins, frames and
+        channels.
+    - It is also checked if the numerical log data in the output file matches exactly that of the input file
+    """
+
+    pargs = make_parser().parse_args()
+
+    # 1. Import a DLIS file using dlisio library
+    dlisio_logical_files = dlis.load(pargs.input_file_name)
+
+    # 2. Re-create the DLIS file in memory as a dliswriter object
+    output_dlis_file = create_from_dlisio(dlisio_logical_files, pargs.minimal_mode)
+
+    # 3. Write the new DLIS file to disk (hopefully with the same contents)
+    output_dlis_file.write(pargs.output_file_name)
+
+    # 4. Checking if log numerical data is preserved
+    compare_log_data(dlisio_logical_files, dlis.load(pargs.output_file_name))
+
+
+def compare_log_data(in_logical_files, reread_logical_files):
+
+    assert len(in_logical_files) == len(reread_logical_files)
+
+    for idx_lf, lf in enumerate(reread_logical_files):
+        assert int(in_logical_files[idx_lf].fileheader.sequencenr) == int(
+            reread_logical_files[idx_lf].fileheader.sequencenr
+        )
+        assert (
+            in_logical_files[idx_lf].fileheader.id
+            == reread_logical_files[idx_lf].fileheader.id
+        )
+        assert (
+            in_logical_files[idx_lf].fileheader.name
+            == reread_logical_files[idx_lf].fileheader.name
+        )
+
+        for idx_o, o in enumerate(lf.origins):
+            # NOTE - creation_time not compared because it is set anew in output file
+            in_origin = in_logical_files[idx_lf].origins[idx_o]
+            out_origin = reread_logical_files[idx_lf].origins[idx_o]
+
+            assert in_origin.file_set_nr == out_origin.file_set_nr
+            assert in_origin.file_id == out_origin.file_id
+            assert in_origin.file_nr == out_origin.file_nr
+            assert in_origin.well_name == out_origin.well_name
+            assert in_origin.file_set_name == out_origin.file_set_name
+            assert in_origin.origin == out_origin.origin
+            assert in_origin.file_type == out_origin.file_type
+            assert in_origin.product == out_origin.product
+            assert in_origin.version == out_origin.version
+            assert in_origin.programs == out_origin.programs
+            assert in_origin.order_nr == out_origin.order_nr
+
+            # NOTE - dliswriter expects int, dlisio a list. rp66v1 doesn't specify
+            if (len(in_origin.descent_nr)):
+                assert in_origin.descent_nr[0] == out_origin.descent_nr[0]
+            else:
+                assert len(out_origin.descent_nr) == 0
+
+            # NOTE - dliswriter expects int, dlisio a list. rp66v1 doesn't specify
+            if (len(in_origin.run_nr)):
+                assert in_origin.run_nr[0] == out_origin.run_nr[0]
+            else:
+                assert len(out_origin.run_nr) == 0
+
+            assert in_origin.well_id == out_origin.well_id
+            assert in_origin.field_name == out_origin.field_name
+            assert in_origin.producer_code == out_origin.producer_code
+            assert in_origin.producer_name == out_origin.producer_name
+            assert in_origin.company == out_origin.company
+            assert in_origin.namespace_name == out_origin.namespace_name
+            assert in_origin.namespace_version == out_origin.namespace_version
+
+        assert len(in_logical_files[idx_lf].frames) == len(
+            reread_logical_files[idx_lf].frames
+        )
+
+        for idx_fr, fr in enumerate(lf.frames):
+            in_frame = in_logical_files[idx_lf].frames[idx_fr]
+            out_frame = reread_logical_files[idx_lf].frames[idx_fr]
+
+            assert in_frame.name == out_frame.name
+            assert in_frame.description == out_frame.description
+            assert in_frame.origin == out_frame.origin
+
+            assert len(in_frame.channels) == len(out_frame.channels)
+
+            for idx_c, c in enumerate(lf.channels):
+                in_channel = in_logical_files[idx_lf].channels[idx_c]
+                out_channel = reread_logical_files[idx_lf].channels[idx_c]
+
+                assert in_channel.dtype.base == out_channel.dtype.base
+                assert in_channel.long_name == out_channel.long_name
+                assert in_channel.units == out_channel.units
+                assert in_channel.origin == out_channel.origin
+                assert in_channel.dimension == out_channel.dimension
+                assert in_channel.element_limit == out_channel.element_limit
+
+                logger.debug("Comparing in and out actual curves data...")
+
+                # np.testing.assert_allclose(in_channel.curves(), out_channel.curves(), rtol=0.5, atol=5e-06)
+                np.testing.assert_equal(in_channel.curves(), out_channel.curves())
+
+    logger.info("Success - Origins, Channels and Frames were preserved.")
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/create_dlis_from_dlisio.py
+++ b/examples/create_dlis_from_dlisio.py
@@ -3,8 +3,6 @@ from dlisio import dlis    # type: ignore  # untyped library
 import numpy as np
 
 from argparse import ArgumentParser
-from utils import prepare_directory
-# from ..src.dliswriter.utils.import_from_dlisio import create_from_dlisio    # type: ignore  # untyped library
 from dliswriter.utils.import_from_dlisio import create_from_dlisio    # type: ignore  # untyped library
 
 logger = logging.getLogger(__name__)

--- a/src/dliswriter/file/file.py
+++ b/src/dliswriter/file/file.py
@@ -266,7 +266,7 @@ class LogicalFile:
         fh_set = eflr_types.FileHeaderSet()
 
         # fh_set.set_name = fh_identifier
-        # FIXME - Issue #39 Setting the name of the file header somehow corrupts the output DLIS file. This may be 
+        # FIXME - Issue #39 Setting the name of the file header somehow corrupts the output DLIS file. This may be
         # probably related to the Issue #14
         # And because of that it's problematic to add the fh_set to the self._eflr_sets and physical_file._eflr_sets,
         # now that we have multiple logical files, each one having their header. This is why we have file_header_item

--- a/src/dliswriter/file/file.py
+++ b/src/dliswriter/file/file.py
@@ -266,8 +266,8 @@ class LogicalFile:
         fh_set = eflr_types.FileHeaderSet()
 
         # fh_set.set_name = fh_identifier
-        # FIXME - Setting the name of the file header somehow corrupts the output DLIS file. This is probably related
-        # to the Issue #14
+        # FIXME - Issue #39 Setting the name of the file header somehow corrupts the output DLIS file. This may be 
+        # probably related to the Issue #14
         # And because of that it's problematic to add the fh_set to the self._eflr_sets and physical_file._eflr_sets,
         # now that we have multiple logical files, each one having their header. This is why we have file_header_item
         # as an attribute, as we see below:
@@ -328,6 +328,12 @@ class LogicalFile:
         """Channels defined for the DLIS."""
 
         return list(self._eflr_sets.get_all_items_for_set_type(eflr_types.OriginSet))
+
+    @property
+    def axes(self) -> list[eflr_types.AxisItem]:
+        """Axes defined for the DLIS."""
+
+        return list(self._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
 
     def add_axis(
         self,

--- a/src/dliswriter/logical_record/eflr_types/file_header.py
+++ b/src/dliswriter/logical_record/eflr_types/file_header.py
@@ -22,8 +22,9 @@ class FileHeaderItem(EFLRItem):
 
     parent: "FileHeaderSet"
 
-    header_id_length_limit = 65             #: max length of the file header name
     max_sequence_number = int(1e10 - 1)     #: max value for sequence number; largest 10-digit integer
+
+    header_id_length_limit = 65             #: max length of the file header name
 
     def __init__(self, header_id: str, parent: "FileHeaderSet", sequence_number: int = 1,
                  identifier: str = '0') -> None:
@@ -87,8 +88,8 @@ class FileHeaderItem(EFLRItem):
         bts += pack_ushort(10)
         bts += get_ascii_bytes(str(self.sequence_number), 10, justify_left=False)
         bts += pack_ushort(int('00100001', 2))
-        bts += pack_ushort(65)
-        bts += get_ascii_bytes(self.header_id, 65, justify_left=True)
+        bts += pack_ushort(self.header_id_length_limit)
+        bts += get_ascii_bytes(self.header_id, self.header_id_length_limit, justify_left=True)
 
         return bts
 

--- a/src/dliswriter/utils/import_from_dlisio.py
+++ b/src/dliswriter/utils/import_from_dlisio.py
@@ -1,7 +1,7 @@
 from dliswriter import DLISFile, LogicalFile, enums, eflr_types, StorageUnitLabel
 from dliswriter.file.eflr_sets_dict import AnyEFLRSet, AnyEFLRItem
 from dliswriter.logical_record.core.eflr import EFLRSet
-from typing import Union, Type, Dict, Generic, Optional
+from typing import Union, Dict, Generic, Optional
 try:
     import dlisio    # type: ignore  # untyped library
 except ImportError:

--- a/src/dliswriter/utils/import_from_dlisio.py
+++ b/src/dliswriter/utils/import_from_dlisio.py
@@ -1,4 +1,7 @@
 from dliswriter import DLISFile, enums, eflr_types, StorageUnitLabel
+from dliswriter.logical_record.core.logical_record import LRMeta
+from dliswriter.file.eflr_sets_dict import AnyEFLRSet, AnyEFLRItem
+from typing import Union
 try:
     import dlisio    # type: ignore  # untyped library
 except ImportError:
@@ -7,7 +10,7 @@ except ImportError:
         "You can install dlisio or reinstall dliswriter calling 'pip install dliswriter[dlisio]'"
     )
 
-from dlisio.dlis.utils.valuetypes import parsevalue    # type: ignore  # untyped library
+from dlisio.dlis.utils.valuetypes import scalar, parsevalue    # type: ignore  # untyped library
 
 import logging
 
@@ -40,14 +43,14 @@ dlisio_to_dliswriter = {
 }
 
 
-def dliswriter_Set(dlisio_type):
+def dliswriter_Set(dlisio_type) -> Union[LRMeta, AnyEFLRSet, None]:
     """
     Output the dliswriter EFLRSet type corresponding to the dlisio_type
     """
-    return dlisio_to_dliswriter.get(dlisio_type, "None")
+    return dlisio_to_dliswriter.get(dlisio_type, None)
 
 
-def is_same_object(obj_dliswriter, obj_dlisio):
+def is_same_object(obj_dliswriter, obj_dlisio) -> bool:
     """
     Compare if an object in dlisio and another in dliswriter representation are the same.
     NOTE - Only the attributes that make a general object unique inside a logical file are compared,
@@ -58,7 +61,7 @@ def is_same_object(obj_dliswriter, obj_dlisio):
         obj_dliswriter.copy_number == obj_dlisio.copynumber
 
 
-def find_in_dliswriter(logical_file, object_from_dlisio):
+def find_in_dliswriter(logical_file, object_from_dlisio) -> Union[AnyEFLRItem, None]:
     """
     Find the dliswriter object in the logical file that is equivalent to object_from_dlisio
     """
@@ -101,7 +104,7 @@ def find_dlisio_objects_in_dliswriter(dlisio_objs, dliswriter_candidates):
     return objs
 
 
-def convert_dlisio_to_int(dlisio_in):
+def convert_dlisio_to_int(dlisio_in) -> Union[int, None]:
     out_nr = None
     if dlisio_in:
         if type(dlisio_in) is not int:
@@ -116,7 +119,7 @@ def convert_dlisio_to_int(dlisio_in):
     return out_nr
 
 
-def add_origins(dlisio_lf, out_logical_file, lf_index):
+def add_origins(dlisio_lf, out_logical_file, lf_index) -> None:
     for idx_o, o in enumerate(dlisio_lf.origins):
         programs = o["PROGRAMS"] if len(o["PROGRAMS"]) != 0 else None
 
@@ -151,7 +154,7 @@ def add_origins(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_axes(dlisio_lf, out_logical_file, lf_index):
+def add_axes(dlisio_lf, out_logical_file, lf_index) -> None:
     for a in dlisio_lf.axes:
         out_logical_file.add_axis(
             name=a.name,
@@ -163,7 +166,7 @@ def add_axes(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_equipments(dlisio_lf, out_logical_file, lf_index):
+def add_equipments(dlisio_lf, out_logical_file, lf_index) -> None:
     for e in dlisio_lf.equipments:
         out_logical_file.add_equipment(
             name=e.name,
@@ -189,7 +192,7 @@ def add_equipments(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_wellrefs(dlisio_lf, out_logical_file, lf_index):
+def add_wellrefs(dlisio_lf, out_logical_file, lf_index) -> None:
     for r in dlisio_lf.wellrefs:
         out_logical_file.add_well_reference_point(
             name=r.name,
@@ -209,7 +212,7 @@ def add_wellrefs(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_zones(dlisio_lf, out_logical_file, lf_index):
+def add_zones(dlisio_lf, out_logical_file, lf_index) -> None:
     for z in dlisio_lf.zones:
         out_logical_file.add_zone(
             name=z.name,
@@ -222,7 +225,7 @@ def add_zones(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_longnames(dlisio_lf, out_logical_file, lf_index):
+def add_longnames(dlisio_lf, out_logical_file, lf_index) -> None:
     for ln in dlisio_lf.longnames:
         out_logical_file.add_long_name(
             name=ln.name,
@@ -246,7 +249,7 @@ def add_longnames(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_calibration_coefficients(dlisio_lf, out_logical_file, lf_index):
+def add_calibration_coefficients(dlisio_lf, out_logical_file, lf_index) -> None:
     for c in dlisio_lf.coefficients:
         coeffs = c.coefficients if len(c.coefficients) else None
         refs = c.references if len(c.references) else None
@@ -264,7 +267,7 @@ def add_calibration_coefficients(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_channels_and_frames(dlisio_lf, out_logical_file, lf_index):
+def add_channels_and_frames(dlisio_lf, out_logical_file, lf_index) -> None:
     out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
     for f, frame in enumerate(dlisio_lf.frames):
 
@@ -283,7 +286,7 @@ def add_channels_and_frames(dlisio_lf, out_logical_file, lf_index):
                 if type(channel.long_name) is str:
                     lname = channel.long_name
                 elif channel.long_name is not None:
-                    lname = find_in_dliswriter(out_logical_file, channel.long_name)
+                    lname = find_in_dliswriter(out_logical_file, channel.long_name)  # type: ignore  # str ruled out
 
             units = None
             if (channel.units):
@@ -333,7 +336,7 @@ def add_channels_and_frames(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_parameters(dlisio_lf, out_logical_file, lf_index):
+def add_parameters(dlisio_lf, out_logical_file, lf_index) -> None:
     out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
     out_zones = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
@@ -348,7 +351,7 @@ def add_parameters(dlisio_lf, out_logical_file, lf_index):
             if type(p.long_name) is str:
                 lname = p.long_name
             elif p.long_name is not None:
-                lname = find_in_dliswriter(out_logical_file, p.long_name)
+                lname = find_in_dliswriter(out_logical_file, p.long_name)  # type: ignore  # str ruled out in else
 
         out_logical_file.add_parameter(
             name=p.name,
@@ -364,7 +367,7 @@ def add_parameters(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_calibrations(dlisio_lf, out_logical_file, lf_index):
+def add_calibrations(dlisio_lf, out_logical_file, lf_index) -> None:
     out_channels = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
     out_coefficients = \
@@ -392,7 +395,7 @@ def add_calibrations(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_measurements(dlisio_lf, out_logical_file, lf_index):
+def add_measurements(dlisio_lf, out_logical_file, lf_index) -> None:
     out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
 
     for m in dlisio_lf.measurements:
@@ -426,7 +429,7 @@ def add_measurements(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_comments(dlisio_lf, out_logical_file, lf_index):
+def add_comments(dlisio_lf, out_logical_file, lf_index) -> None:
     for c in dlisio_lf.comments:
         out_logical_file.add_comment(
             name=c.name,
@@ -436,9 +439,10 @@ def add_comments(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_processes(dlisio_lf, out_logical_file, lf_index):
-    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
-    out_parameters = \
+def add_processes(dlisio_lf, out_logical_file, lf_index) -> None:
+    out_axes: list[eflr_types.AxisItem] = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    out_parameters: list[eflr_types.ParameterItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ParameterSet))
 
     for p in dlisio_lf.processes:
@@ -462,9 +466,10 @@ def add_processes(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_computations(dlisio_lf, out_logical_file, lf_index):
-    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
-    out_zones = \
+def add_computations(dlisio_lf, out_logical_file, lf_index) -> None:
+    out_axes: list[eflr_types.AxisItem] = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    out_zones: list[eflr_types.ZoneItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
 
     for c in dlisio_lf.computations:
@@ -473,7 +478,7 @@ def add_computations(dlisio_lf, out_logical_file, lf_index):
             if type(c.long_name) is str:
                 lname = c.long_name
             elif c.long_name is not None:
-                lname = find_in_dliswriter(out_logical_file, c.long_name)
+                lname = find_in_dliswriter(out_logical_file, c.long_name)  # type: ignore  # str ruled out in else
 
         axes_refs = find_dlisio_objects_in_dliswriter(c.axis, out_axes)
         zones_refs = find_dlisio_objects_in_dliswriter(c.zones, out_zones)
@@ -493,16 +498,16 @@ def add_computations(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_groups(dlisio_lf, out_logical_file, lf_index):
+def add_groups(dlisio_lf, out_logical_file, lf_index) -> None:
     for g in dlisio_lf.groups:
-        olist = []
+        olist = []  # type: ignore
 
         for o in g.objects:
             ref = find_in_dliswriter(out_logical_file, o)
             if ref:
                 olist.append(ref)
         if not len(olist):
-            olist = None
+            olist = None  # type: ignore
 
         out_logical_file.add_group(
             name=g.name,
@@ -512,7 +517,7 @@ def add_groups(dlisio_lf, out_logical_file, lf_index):
             origin_reference=g.origin,
         )
 
-    out_groups = \
+    out_groups: list[eflr_types.GroupItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.GroupSet))
 
     for idx_g, group in enumerate(out_groups):
@@ -524,7 +529,7 @@ def add_groups(dlisio_lf, out_logical_file, lf_index):
             group.group_list.value = group_list
 
 
-def add_messages(dlisio_lf, out_logical_file, lf_index):
+def add_messages(dlisio_lf, out_logical_file, lf_index) -> None:
     for m in dlisio_lf.messages:
         out_logical_file.add_message(
             name=m.name,
@@ -540,8 +545,8 @@ def add_messages(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_paths(dlisio_lf, out_logical_file, lf_index):
-    out_channels = \
+def add_paths(dlisio_lf, out_logical_file, lf_index) -> None:
+    out_channels: list[eflr_types.ChannelItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
 
     for p in dlisio_lf.paths:
@@ -578,10 +583,10 @@ def add_paths(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_splices(dlisio_lf, out_logical_file, lf_index):
-    out_channels = \
+def add_splices(dlisio_lf, out_logical_file, lf_index) -> None:
+    out_channels: list[eflr_types.ChannelItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
-    out_zones = \
+    out_zones: list[eflr_types.ZoneItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
 
     for s in dlisio_lf.splices:
@@ -599,12 +604,12 @@ def add_splices(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_tools(dlisio_lf, out_logical_file, lf_index):
-    out_channels = \
+def add_tools(dlisio_lf, out_logical_file, lf_index) -> None:
+    out_channels: list[eflr_types.ChannelItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
-    out_parameters = \
+    out_parameters: list[eflr_types.ParameterItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ParameterSet))
-    out_equipments = \
+    out_equipments: list[eflr_types.EquipmentItem] = \
         list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.EquipmentSet))
 
     for t in dlisio_lf.tools:
@@ -625,7 +630,7 @@ def add_tools(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def add_noformats(dlisio_lf, out_logical_file, lf_index):
+def add_noformats(dlisio_lf, out_logical_file, lf_index) -> None:
     for n in dlisio_lf.noformats:
         out_logical_file.add_no_format(
             name=n.name,
@@ -636,7 +641,7 @@ def add_noformats(dlisio_lf, out_logical_file, lf_index):
         )
 
 
-def create_from_dlisio(in_logical_files, minimal):
+def create_from_dlisio(in_logical_files, minimal) -> DLISFile:
     """
     Write a DLIS file from a dlisio object.
 
@@ -683,7 +688,7 @@ def create_from_dlisio(in_logical_files, minimal):
 
         add_origins(lf, out_logical_files[idx_lf], idx_lf)
 
-        if not minimal:
+        if minimal.lower() == "false":
             add_axes(lf, out_logical_files[idx_lf], idx_lf)
             add_measurements(lf, out_logical_files[idx_lf], idx_lf)
             add_equipments(lf, out_logical_files[idx_lf], idx_lf)
@@ -694,7 +699,7 @@ def create_from_dlisio(in_logical_files, minimal):
 
         add_channels_and_frames(lf, out_logical_files[idx_lf], idx_lf)
 
-        if not minimal:
+        if minimal.lower() == "false":
             add_parameters(lf, out_logical_files[idx_lf], idx_lf)
             add_calibrations(lf, out_logical_files[idx_lf], idx_lf)
             add_comments(lf, out_logical_files[idx_lf], idx_lf)
@@ -709,25 +714,25 @@ def create_from_dlisio(in_logical_files, minimal):
 
             # Channels, Computations and Measurements can have references to any objects. We set them here
 
-            out_channels = \
+            out_channels: list[eflr_types.ChannelItem] = \
                 list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
 
             for idx_c, out_c in enumerate(out_channels):
                 ref_source = find_in_dliswriter(out_logical_file, lf.channels[idx_c].source)
                 out_c.source.value = ref_source
 
-            out_computations = \
+            out_computations: list[eflr_types.ComputationItem] = \
                 list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ComputationSet))
 
-            out_measurements = \
+            out_measurements: list[eflr_types.CalibrationMeasurementItem] = \
                 list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.CalibrationMeasurementSet))
 
-            for idx_c, out_c in enumerate(out_computations):
+            for idx_c, out_cp in enumerate(out_computations):
                 ref_source = find_in_dliswriter(out_logical_file, lf.computations[idx_c].source)
-                out_c.source.value = ref_source
+                out_cp.source.value = ref_source
 
             for idx_m, out_m in enumerate(out_measurements):
                 ref_source = find_in_dliswriter(out_logical_file, lf.measurements[idx_m].source)
-                out_m.source.value = ref_source
+                out_m.measurement_source.value = ref_source
 
     return dlisFile

--- a/src/dliswriter/utils/import_from_dlisio.py
+++ b/src/dliswriter/utils/import_from_dlisio.py
@@ -1,0 +1,733 @@
+from dliswriter import DLISFile, enums, eflr_types, StorageUnitLabel
+try:
+    import dlisio    # type: ignore  # untyped library
+except ImportError:
+    raise ImportError(
+        "The 'dlisio' library is required to use this function. "
+        "You can install dlisio or reinstall dliswriter calling 'pip install dliswriter[dlisio]'"
+    )
+
+from dlisio.dlis.utils.valuetypes import parsevalue    # type: ignore  # untyped library
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# dliswriter EFLRSets corresponding to dlisio types
+dlisio_to_dliswriter = {
+    dlisio.dlis.computation.Computation: eflr_types.ComputationSet,
+    dlisio.dlis.axis.Axis: eflr_types.AxisSet,
+    dlisio.dlis.coefficient.Coefficient: eflr_types.CalibrationCoefficientSet,
+    dlisio.dlis.calibration.Calibration: eflr_types.CalibrationSet,
+    dlisio.dlis.measurement.Measurement: eflr_types.CalibrationMeasurementSet,
+    dlisio.dlis.channel.Channel: eflr_types.ChannelSet,
+    dlisio.dlis.comment.Comment: eflr_types.CommentSet,
+    dlisio.dlis.equipment.Equipment: eflr_types.EquipmentSet,
+    dlisio.dlis.fileheader.Fileheader: eflr_types.FileHeaderSet,
+    dlisio.dlis.frame.Frame: eflr_types.FrameSet,
+    dlisio.dlis.group.Group: eflr_types.GroupSet,
+    dlisio.dlis.longname.Longname: eflr_types.LongNameSet,
+    dlisio.dlis.message.Message: eflr_types.MessageSet,
+    dlisio.dlis.noformat.Noformat: eflr_types.NoFormatSet,
+    dlisio.dlis.origin.Origin: eflr_types.OriginSet,
+    dlisio.dlis.parameter.Parameter: eflr_types.ParameterSet,
+    dlisio.dlis.path.Path: eflr_types.PathSet,
+    dlisio.dlis.process.Process: eflr_types.ProcessSet,
+    dlisio.dlis.splice.Splice: eflr_types.SpliceSet,
+    dlisio.dlis.tool.Tool: eflr_types.ToolSet,
+    dlisio.dlis.wellref.Wellref: eflr_types.WellReferencePointSet,
+    dlisio.dlis.zone.Zone: eflr_types.ZoneSet
+}
+
+
+def dliswriter_Set(dlisio_type):
+    """
+    Output the dliswriter EFLRSet type corresponding to the dlisio_type
+    """
+    return dlisio_to_dliswriter.get(dlisio_type, "None")
+
+
+def is_same_object(obj_dliswriter, obj_dlisio):
+    """
+    Compare if an object in dlisio and another in dliswriter representation are the same.
+    NOTE - Only the attributes that make a general object unique inside a logical file are compared,
+    while the remainging attributes are not checked
+    """
+    return obj_dliswriter.name == obj_dlisio.name and \
+        obj_dliswriter.origin_reference == obj_dlisio.origin and \
+        obj_dliswriter.copy_number == obj_dlisio.copynumber
+
+
+def find_in_dliswriter(logical_file, object_from_dlisio):
+    """
+    Find the dliswriter object in the logical file that is equivalent to object_from_dlisio
+    """
+    if not object_from_dlisio:
+        return None
+
+    ref = None
+    candidates = \
+        list(logical_file._eflr_sets.get_all_items_for_set_type(dliswriter_Set(type(object_from_dlisio))))
+    for c in candidates:
+        if is_same_object(c, object_from_dlisio):
+            ref = c
+            break  # NOTE - We return here, as it shouldn't be possible to have more than one match
+
+    if not ref:
+        raise RuntimeError(
+            f"Couldn't find in dliswriter logical file the reference of dlisio's object {object_from_dlisio}.")
+
+    return ref
+
+
+def find_dlisio_objects_in_dliswriter(dlisio_objs, dliswriter_candidates):
+    """
+    Find the list of objects in dliswriter_candidates that matches the list of objects dlisio_objs
+    """
+    if not dlisio_objs or not len(dlisio_objs):
+        return None
+
+    objs = []
+    for dlisw in dliswriter_candidates:
+        for o in dlisio_objs:
+            if is_same_object(dlisw, o):
+                objs.append(dlisw)
+
+    if len(objs) != len(dlisio_objs):
+        msg = f"Couldn't find in dliswriter logical file some or all {type(dliswriter_candidates[0])} references "
+        f"listed in list of dlisio objects {dlisio_objs}"
+        raise RuntimeError(msg)
+
+    return objs
+
+
+def convert_dlisio_to_int(dlisio_in):
+    out_nr = None
+    if dlisio_in:
+        if type(dlisio_in) is not int:
+            out_nr = (
+                int(parsevalue(dlisio_in, scalar))
+                if len(dlisio_in) != 0
+                else None
+            )
+        else:
+            out_nr = dlisio_in
+
+    return out_nr
+
+
+def add_origins(dlisio_lf, out_logical_file, lf_index):
+    for idx_o, o in enumerate(dlisio_lf.origins):
+        programs = o["PROGRAMS"] if len(o["PROGRAMS"]) != 0 else None
+
+        # NOTE - dliswriter expects int, dlisio a list. rp66v1 doesn't specify
+        run_nr = convert_dlisio_to_int(o["RUN-NUMBER"])
+
+        # NOTE - dliswriter expects int, dlisio a list. rp66v1 doesn't specify
+        descent_nr = convert_dlisio_to_int(o["DESCENT-NUMBER"])
+
+        out_logical_file.add_origin(
+            name=o.name,
+            origin_reference=o.origin,
+            file_set_number=o["FILE-SET-NUMBER"],
+            file_set_name=o["FILE-SET-NAME"],
+            file_number=o["FILE-NUMBER"],
+            file_type=o["FILE-TYPE"],
+            product=o["PRODUCT"],
+            version=o["VERSION"],
+            programs=programs,
+            order_number=o["ORDER-NUMBER"],
+            descent_number=descent_nr,
+            run_number=run_nr,
+            well_id=o["WELL-ID"],
+            well_name=o["WELL-NAME"],
+            field_name=o["FIELD-NAME"],
+            producer_code=o["PRODUCER-CODE"],
+            producer_name=o["PRODUCER-NAME"],
+            company=o["COMPANY"],
+            name_space_name=o["NAME-SPACE-NAME"],
+            name_space_version=o["NAME-SPACE-VERSION"],
+            set_name=f"ORIGIN-LF{lf_index}",
+        )
+
+
+def add_axes(dlisio_lf, out_logical_file, lf_index):
+    for a in dlisio_lf.axes:
+        out_logical_file.add_axis(
+            name=a.name,
+            axis_id=a.axis_id,
+            coordinates=a.coordinates,
+            # spacing=a.spacing,  NOTE - not always dlisio will return a number - rp66v1 doesn't specify a type
+            set_name=f"AXES-LF{lf_index}",
+            origin_reference=a.origin
+        )
+
+
+def add_equipments(dlisio_lf, out_logical_file, lf_index):
+    for e in dlisio_lf.equipments:
+        out_logical_file.add_equipment(
+            name=e.name,
+            trademark_name=e.trademark_name,
+            status=e.status,
+            eq_type=e.generic_type,
+            serial_number=e.serial_number,
+            location=e.location,
+            height=e.height,
+            length=e.length,
+            minimum_diameter=e.diameter_min,
+            maximum_diameter=e.diameter_max,
+            volume=e.volume,
+            weight=e.weight,
+            hole_size=e.hole_size,
+            pressure=e.pressure,
+            temperature=e.temperature,
+            vertical_depth=e.vertical_depth,
+            radial_drift=e.radial_drift,
+            angular_drift=e.angular_drift,
+            set_name=f"EQUIPMENTS-LF{lf_index}",
+            origin_reference=e.origin,
+        )
+
+
+def add_wellrefs(dlisio_lf, out_logical_file, lf_index):
+    for r in dlisio_lf.wellrefs:
+        out_logical_file.add_well_reference_point(
+            name=r.name,
+            permanent_datum=r.permanent_datum,
+            vertical_zero=r.vertical_zero,
+            permanent_datum_elevation=r.permanent_datum_elevation,
+            above_permanent_datum=r.above_permanent_datum,
+            magnetic_declination=r.magnetic_declination,
+            coordinate_1_name=r['COORDINATE-1-NAME'],
+            coordinate_1_value=r['COORDINATE-1-VALUE'],
+            coordinate_2_name=r['COORDINATE-2-NAME'],
+            coordinate_2_value=r['COORDINATE-2-VALUE'],
+            coordinate_3_name=r['COORDINATE-3-NAME'],
+            coordinate_3_value=r['COORDINATE-3-VALUE'],
+            set_name=f"WELLREFS-LF{lf_index}",
+            origin_reference=r.origin,
+        )
+
+
+def add_zones(dlisio_lf, out_logical_file, lf_index):
+    for z in dlisio_lf.zones:
+        out_logical_file.add_zone(
+            name=z.name,
+            description=z.description,
+            domain=z.domain,
+            maximum=z.maximum,
+            minimum=z.minimum,
+            set_name=f"ZONES-LF{lf_index}",
+            origin_reference=z.origin,
+        )
+
+
+def add_longnames(dlisio_lf, out_logical_file, lf_index):
+    for ln in dlisio_lf.longnames:
+        out_logical_file.add_long_name(
+            name=ln.name,
+            general_modifier=ln.modifier,
+            quantity=ln.quantity,
+            quantity_modifier=ln.quantity_mod,
+            altered_form=ln.altered_form,
+            entity=ln.entity,
+            entity_modifier=ln.entity_mod,
+            entity_number=ln.entity_nr,
+            entity_part=ln.entity_part,
+            entity_part_number=ln.entity_part_nr,
+            generic_source=ln.generic_source,
+            source_part=ln.source_part,
+            source_part_number=ln.source_part_nr,
+            conditions=ln.conditions,
+            standard_symbol=ln.standard_symbol,
+            private_symbol=ln.private_symbol,
+            set_name=f"LONGNAMES-LF{lf_index}",
+            origin_reference=ln.origin,
+        )
+
+
+def add_calibration_coefficients(dlisio_lf, out_logical_file, lf_index):
+    for c in dlisio_lf.coefficients:
+        coeffs = c.coefficients if len(c.coefficients) else None
+        refs = c.references if len(c.references) else None
+        plus = c.plus_tolerance if len(c.plus_tolerance) else None
+        minus = c.minus_tolerance if len(c.minus_tolerance) else None
+        out_logical_file.add_calibration_coefficient(
+            name=c.name,
+            label=c.label,
+            coefficients=coeffs,
+            references=refs,
+            plus_tolerances=plus,
+            minus_tolerances=minus,
+            set_name=f"COEFFICIENTS-LF{lf_index}",
+            origin_reference=c.origin,
+        )
+
+
+def add_channels_and_frames(dlisio_lf, out_logical_file, lf_index):
+    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    for f, frame in enumerate(dlisio_lf.frames):
+
+        channels = []
+
+        for c, channel in enumerate(frame.channels):
+
+            properties = channel.properties if len(channel.properties) != 0 else None
+
+            # finding references of axes
+            axes = find_dlisio_objects_in_dliswriter(channel.axis, out_axes)
+
+            # finding reference of longname
+            lname = None
+            if (channel.long_name):
+                if type(channel.long_name) is str:
+                    lname = channel.long_name
+                elif channel.long_name is not None:
+                    lname = find_in_dliswriter(out_logical_file, channel.long_name)
+
+            units = None
+            if (channel.units):
+                if type(channel.units) is not str:
+                    units = channel.units.decode("latin1")  # Normally a good guess. Degree symbol, for example
+                else:
+                    units = channel.units
+
+            # minimum_value, maximum_value and source should be automatically set internally
+            # NOTE - frame.curves() would be faster than channel-wise retrieveing channel.curves()
+            # (https://dlisio.readthedocs.io/en/latest/dlis/api.html#dlisio.dlis.Channel.curves)
+            channels.append(
+                out_logical_file.add_channel(
+                    name=channel.name,
+                    # dataset_name: Optional[str] = None,  not in the rp66v1 specification, nor in dlisio
+                    data=channel.curves(),
+                    cast_dtype=channel.dtype.base,
+                    long_name=lname,
+                    dimension=channel.dimension,
+                    element_limit=channel.element_limit,
+                    properties=properties,
+                    axis=axes,
+                    units=units,
+                    set_name=f"CHANNELS-LF{lf_index}-F{f}",
+                    origin_reference=frame.origin,
+                )
+            )
+
+        if len(channels) == 0:  # dliswriter doesn't allow frames without channels
+            continue
+
+        index_type = frame.index_type
+        if frame.index_type not in [enums.FrameIndexType.ANGULAR_DRIFT, enums.FrameIndexType.BOREHOLE_DEPTH,
+                                    enums.FrameIndexType.NON_STANDARD, enums.FrameIndexType.RADIAL_DRIFT,
+                                    enums.FrameIndexType.VERTICAL_DEPTH]:
+            logger.warning(f"Frame index_type of Frame {frame.name} doesn't belong to the rp66v1 allowed values. "
+                           f"Potentially unsafe.")
+
+        out_logical_file.add_frame(
+            name=frame.name,
+            channels=channels,
+            description=frame.description,
+            encrypted=int(frame.encrypted),
+            set_name=f"FRAMES-LF{lf_index}",
+            origin_reference=frame.origin,
+            index_type=index_type,
+        )
+
+
+def add_parameters(dlisio_lf, out_logical_file, lf_index):
+    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    out_zones = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
+
+    for p in dlisio_lf.parameters:
+        axes_refs = find_dlisio_objects_in_dliswriter(p.axis, out_axes)
+        zones_refs = find_dlisio_objects_in_dliswriter(p.zones, out_zones)
+
+        # finding reference of longname
+        lname = None
+        if (p.long_name):
+            if type(p.long_name) is str:
+                lname = p.long_name
+            elif p.long_name is not None:
+                lname = find_in_dliswriter(out_logical_file, p.long_name)
+
+        out_logical_file.add_parameter(
+            name=p.name,
+            long_name=lname,
+            # dimension=p.dimension,  NOTE - Check: Some tests lead to to errors at dliswriter checks
+            values=p.values.tolist(),
+            # FIXME - rp66v1 4.4.4: 'The AXIS Attribute is a List of references to one or more Axis Objects'
+            # But dliswriter expects a single AxisItem. We'll use the first one from dlisio
+            axis=axes_refs[0] if axes_refs else None,
+            zones=zones_refs,
+            set_name=f"PARAMETERS-LF{lf_index}",
+            origin_reference=p.origin,
+        )
+
+
+def add_calibrations(dlisio_lf, out_logical_file, lf_index):
+    out_channels = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
+    out_coefficients = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.CalibrationCoefficientSet))
+    out_measurements = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.CalibrationMeasurementSet))
+
+    for c in dlisio_lf.calibrations:
+        cal_channels_refs = find_dlisio_objects_in_dliswriter(c.calibrated, out_channels)
+        uncal_channels_refs = find_dlisio_objects_in_dliswriter(c.uncalibrated, out_channels)
+        coeffs_refs = find_dlisio_objects_in_dliswriter(c.coefficients, out_coefficients)
+        measurements_refs = find_dlisio_objects_in_dliswriter(c.measurements, out_measurements)
+        parameters_refs = find_dlisio_objects_in_dliswriter(c.parameters, out_measurements)
+
+        out_logical_file.add_calibration(
+            name=c.name,
+            calibrated_channels=cal_channels_refs,
+            uncalibrated_channels=uncal_channels_refs,
+            coefficients=coeffs_refs,
+            measurements=measurements_refs,
+            parameters=parameters_refs,
+            method=c.method,
+            set_name=f"PARAMETERS-LF{lf_index}",
+            origin_reference=c.origin
+        )
+
+
+def add_measurements(dlisio_lf, out_logical_file, lf_index):
+    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+
+    for m in dlisio_lf.measurements:
+        phase = m.phase
+        if m.phase not in [enums.CalibrationMeasurementPhase.BEFORE, enums.CalibrationMeasurementPhase.AFTER,
+           enums.CalibrationMeasurementPhase.MASTER]:
+            logger.warning(f"Measurement {m.name} - phase should be 'AFTER', 'BEFORE' or 'MASTER'. Potentially unsafe.")
+
+        axes_refs = None
+        if (m.axis and len(m.axis)):
+            axes_refs = find_dlisio_objects_in_dliswriter(m.axis, out_axes)
+
+        out_logical_file.add_calibration_measurement(
+            name=m.name,
+            phase=phase,
+            measurement_type=m.mtype,
+            dimension=m.dimension,
+            axis=axes_refs,
+            measurement=m["MEASUREMENT"],
+            sample_count=m.samplecount,
+            maximum_deviation=m.max_deviation.tolist(),
+            standard_deviation=m.std_deviation.tolist(),
+            begin_time=m.begin_time,
+            duration=m.duration,
+            reference=m.reference.tolist(),
+            standard=m.standard,
+            plus_tolerance=m.plus_tolerance.tolist(),
+            minus_tolerance=m.minus_tolerance.tolist(),
+            set_name=f"MESSAGES-LF{lf_index}",
+            origin_reference=m.origin,
+        )
+
+
+def add_comments(dlisio_lf, out_logical_file, lf_index):
+    for c in dlisio_lf.comments:
+        out_logical_file.add_comment(
+            name=c.name,
+            text=c.text,
+            set_name=f"COMMENTS-LF{lf_index}",
+            origin_reference=c.origin,
+        )
+
+
+def add_processes(dlisio_lf, out_logical_file, lf_index):
+    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    out_parameters = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ParameterSet))
+
+    for p in dlisio_lf.processes:
+        input_channels_refs = find_dlisio_objects_in_dliswriter(p.input_channels, out_axes)
+        output_channels_refs = find_dlisio_objects_in_dliswriter(p.output_channels, out_axes)
+        parameters_refs = find_dlisio_objects_in_dliswriter(p.parameters, out_parameters)
+
+        out_logical_file.add_process(
+            name=p.name,
+            description=p.description,
+            trademark_name=p.trademark_name,
+            version=p.version,
+            properties=p.properties,
+            status=p.status,
+            input_channels=input_channels_refs,
+            output_channels=output_channels_refs,
+            parameters=parameters_refs,
+            comments=p.comments,
+            set_name=f"PARAMETERS-LF{lf_index}",
+            origin_reference=p.origin,
+        )
+
+
+def add_computations(dlisio_lf, out_logical_file, lf_index):
+    out_axes = list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.AxisSet))
+    out_zones = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
+
+    for c in dlisio_lf.computations:
+        lname = None
+        if (c.long_name):
+            if type(c.long_name) is str:
+                lname = c.long_name
+            elif c.long_name is not None:
+                lname = find_in_dliswriter(out_logical_file, c.long_name)
+
+        axes_refs = find_dlisio_objects_in_dliswriter(c.axis, out_axes)
+        zones_refs = find_dlisio_objects_in_dliswriter(c.zones, out_zones)
+
+        # dim = c.dimension if c.dimension else None
+
+        out_logical_file.add_computation(
+            name=c.name,
+            long_name=lname,
+            properties=c.properties,
+            # dimension=dim,
+            axis=axes_refs,
+            zones=zones_refs,
+            values=c.values.tolist(),
+            set_name=f"COMPUTATION-LF{lf_index}",
+            origin_reference=c.origin,
+        )
+
+
+def add_groups(dlisio_lf, out_logical_file, lf_index):
+    for g in dlisio_lf.groups:
+        olist = []
+
+        for o in g.objects:
+            ref = find_in_dliswriter(out_logical_file, o)
+            if ref:
+                olist.append(ref)
+        if not len(olist):
+            olist = None
+
+        out_logical_file.add_group(
+            name=g.name,
+            description=g.description,
+            object_list=olist,
+            set_name=f"GROUPS-LF{lf_index}",
+            origin_reference=g.origin,
+        )
+
+    out_groups = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.GroupSet))
+
+    for idx_g, group in enumerate(out_groups):
+        group_list = []
+        for g in dlisio_lf.groups:
+            if (group.name == g.name):
+                group_list.append(group)
+        if len(group_list) > 0:
+            group.group_list.value = group_list
+
+
+def add_messages(dlisio_lf, out_logical_file, lf_index):
+    for m in dlisio_lf.messages:
+        out_logical_file.add_message(
+            name=m.name,
+            message_type=m.message_type,
+            time=m.time,                        # NOTE - m.time is crtime. time is dtime_or_number_type
+            borehole_drift=m.borehole_drift,
+            vertical_depth=m.vertical_depth,
+            radial_drift=m.radial_drift,
+            angular_drift=m.angular_drift,
+            text=m.text,
+            set_name=f"MESSAGES-LF{lf_index}",
+            origin_reference=m.origin,
+        )
+
+
+def add_paths(dlisio_lf, out_logical_file, lf_index):
+    out_channels = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
+
+    for p in dlisio_lf.paths:
+        well_rp_ref = find_in_dliswriter(out_logical_file, p.well_reference_point)
+        frame_ref = find_in_dliswriter(out_logical_file, p.frame)
+
+        channel_refs = find_dlisio_objects_in_dliswriter(p.value, out_channels)
+        borehole_depth_ref = find_in_dliswriter(out_logical_file, p.borehole_depth)
+        vertical_depth_ref = find_in_dliswriter(out_logical_file, p.vertical_depth)
+        radial_drift_ref = find_in_dliswriter(out_logical_file, p.radial_drift)
+        angular_drift_ref = find_in_dliswriter(out_logical_file, p.angular_drift)
+
+        # From file.py's add_frame: 'This Attribute should not be present if the Frame Type
+        # for the current Path has an Index-Type Value of TIME.'
+        time_ref = None
+        if (frame_ref and frame_ref.index_type != "TIME"):
+            time_ref = find_in_dliswriter(out_logical_file, p.time)
+
+        out_logical_file.add_path(
+            name=p.name,
+            frame_type=frame_ref,
+            well_reference_point=well_rp_ref,
+            value=channel_refs,
+            borehole_depth=borehole_depth_ref,
+            vertical_depth=vertical_depth_ref,
+            radial_drift=radial_drift_ref,
+            angular_drift=angular_drift_ref,
+            time=time_ref,
+            depth_offset=p.depth_offset,
+            measure_point_offset=p.measure_point_offset,
+            tool_zero_offset=p.tool_zero_offset,
+            set_name=f"PATHS-LF{lf_index}",
+            origin_reference=p.origin,
+        )
+
+
+def add_splices(dlisio_lf, out_logical_file, lf_index):
+    out_channels = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
+    out_zones = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ZoneSet))
+
+    for s in dlisio_lf.splices:
+        output_channel_ref = find_in_dliswriter(out_logical_file, s.output_channel)
+        input_channels_refs = find_dlisio_objects_in_dliswriter(s.input_channels, out_channels)
+        zones_refs = find_dlisio_objects_in_dliswriter(s.zones, out_zones)
+
+        out_logical_file.add_splice(
+            name=s.name,
+            output_channel=output_channel_ref,
+            input_channels=input_channels_refs,
+            zones=zones_refs,
+            set_name=f"SPLICES-LF{lf_index}",
+            origin_reference=s.origin,
+        )
+
+
+def add_tools(dlisio_lf, out_logical_file, lf_index):
+    out_channels = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
+    out_parameters = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ParameterSet))
+    out_equipments = \
+        list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.EquipmentSet))
+
+    for t in dlisio_lf.tools:
+        output_channels_refs = find_dlisio_objects_in_dliswriter(t.channels, out_channels)
+        out_parameters_refs = find_dlisio_objects_in_dliswriter(t.parameters, out_parameters)
+        equipments_refs = find_dlisio_objects_in_dliswriter(t.parts, out_equipments)
+
+        out_logical_file.add_tool(
+            name=t.name,
+            trademark_name=t.trademark_name,
+            generic_name=t.generic_name,
+            parts=equipments_refs,
+            status=t.status,
+            channels=output_channels_refs,
+            parameters=out_parameters_refs,
+            set_name=f"TOOLS-LF{lf_index}",
+            origin_reference=t.origin,
+        )
+
+
+def add_noformats(dlisio_lf, out_logical_file, lf_index):
+    for n in dlisio_lf.noformats:
+        out_logical_file.add_no_format(
+            name=n.name,
+            consumer_name=n.consumer_name,
+            description=n.description,
+            set_name=f"NOFORMATS-LF{lf_index}",
+            origin_reference=n.origin,
+        )
+
+
+def create_from_dlisio(in_logical_files, minimal):
+    """
+    Write a DLIS file from a dlisio object.
+
+    Args:
+        in_logical_files: Logical files read with dlisio library
+        minimal: if True, just the logical files, origins, frames and channels are passed to the output file
+
+    Raises:
+        ImportError: If dlisio is not installed.
+    """
+
+    out_logical_files = []
+
+    first_logical_file = in_logical_files[0]
+
+    in_SUL = first_logical_file.storage_label()
+
+    out_physical_file_storage_label = StorageUnitLabel(
+        in_SUL["id"], in_SUL["sequence"], in_SUL["maxlen"]
+    )
+
+    dlisFile = DLISFile(
+        storage_unit_label=out_physical_file_storage_label,
+    )
+
+    for idx_lf, lf in enumerate(in_logical_files):
+
+        # First, adding a logical file and its header to the DLIS file
+
+        in_fheader = lf.fileheader
+
+        in_fheaderid_truncated = in_fheader.id
+        # max header id length (rp66v1 section 5.1.)
+        if len(in_fheader.id) > eflr_types.FileHeaderItem.header_id_length_limit:
+            in_fheaderid_truncated = in_fheader.id[:eflr_types.FileHeaderItem.header_id_length_limit]
+
+        out_logical_file = dlisFile.add_logical_file(
+            fh_id=in_fheaderid_truncated,
+            fh_sequence_number=int(in_fheader.sequencenr),
+            fh_identifier="0"  # single-character. This is specific to dliswriter
+        )
+
+        out_logical_files.append(out_logical_file)
+
+        add_origins(lf, out_logical_files[idx_lf], idx_lf)
+
+        if not minimal:
+            add_axes(lf, out_logical_files[idx_lf], idx_lf)
+            add_measurements(lf, out_logical_files[idx_lf], idx_lf)
+            add_equipments(lf, out_logical_files[idx_lf], idx_lf)
+            add_wellrefs(lf, out_logical_files[idx_lf], idx_lf)
+            add_zones(lf, out_logical_files[idx_lf], idx_lf)
+            add_longnames(lf, out_logical_files[idx_lf], idx_lf)
+            add_calibration_coefficients(lf, out_logical_files[idx_lf], idx_lf)
+
+        add_channels_and_frames(lf, out_logical_files[idx_lf], idx_lf)
+
+        if not minimal:
+            add_parameters(lf, out_logical_files[idx_lf], idx_lf)
+            add_calibrations(lf, out_logical_files[idx_lf], idx_lf)
+            add_comments(lf, out_logical_files[idx_lf], idx_lf)
+            add_processes(lf, out_logical_files[idx_lf], idx_lf)
+            add_computations(lf, out_logical_files[idx_lf], idx_lf)
+            add_messages(lf, out_logical_files[idx_lf], idx_lf)
+            add_groups(lf, out_logical_files[idx_lf], idx_lf)
+            add_paths(lf, out_logical_files[idx_lf], idx_lf)
+            add_splices(lf, out_logical_files[idx_lf], idx_lf)
+            add_tools(lf, out_logical_files[idx_lf], idx_lf)
+            add_noformats(lf, out_logical_files[idx_lf], idx_lf)
+
+            # Channels, Computations and Measurements can have references to any objects. We set them here
+
+            out_channels = \
+                list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ChannelSet))
+
+            for idx_c, out_c in enumerate(out_channels):
+                ref_source = find_in_dliswriter(out_logical_file, lf.channels[idx_c].source)
+                out_c.source.value = ref_source
+
+            out_computations = \
+                list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.ComputationSet))
+
+            out_measurements = \
+                list(out_logical_file._eflr_sets.get_all_items_for_set_type(eflr_types.CalibrationMeasurementSet))
+
+            for idx_c, out_c in enumerate(out_computations):
+                ref_source = find_in_dliswriter(out_logical_file, lf.computations[idx_c].source)
+                out_c.source.value = ref_source
+
+            for idx_m, out_m in enumerate(out_measurements):
+                ref_source = find_in_dliswriter(out_logical_file, lf.measurements[idx_m].source)
+                out_m.source.value = ref_source
+
+    return dlisFile


### PR DESCRIPTION
Hi,

- I added a helper /utils/import_from_dlisio.py - Passes all DLIS data of a file read with dlisio to a dliswriter DLISFile object.
  - Also included a `minimal` option, to pass along just the logical files, origins, frames and channels. This is to facilitate for users that are solely interested in the numeric log data and could be stopped by problems in the large amount of other objects of the DLIS specification, that can cause problems.

- Also added an examples/create_dlis_from_dlisio.py showing how to use it and comparing the log numeric data of the input and output files.

